### PR TITLE
fix(components): missing closing tag card #23

### DIFF
--- a/public/components/cards/23.html
+++ b/public/components/cards/23.html
@@ -23,7 +23,7 @@
       <div>
         <dt class="sr-only">
           Address
-        </dd>
+        </dt>
 
         <dd class="font-medium">
           123 Wallaby Avenue, Park Road


### PR DESCRIPTION
Fixes the missing `</dt>` tag at `public/components/cards/23.html:26`.