### PR TITLE
update/site/nested-collections

### DIFF
--- a/components/collection/card.tsx
+++ b/components/collection/card.tsx
@@ -10,10 +10,10 @@ type Props = {
 }
 
 const Card: FunctionComponent<Props> = ({ item }) => {
-  const { title, slug, emoji, count, tags } = item
+  const { title, slug, emoji, count, tags, category } = item
 
   return (
-    <Link href={`/components/${slug}`}>
+    <Link href={`/components/${category}/${slug}`}>
       <a className="relative block group">
         <span
           className="absolute inset-0 border-2 border-black border-dashed rounded-lg"

--- a/interface/component.ts
+++ b/interface/component.ts
@@ -19,4 +19,5 @@ export interface ComponentCard {
   emoji: string
   count: number
   tags?: string[]
+  category: string
 }

--- a/lib/components.ts
+++ b/lib/components.ts
@@ -43,11 +43,12 @@ export function getComponentBySlug(slug: string, fields: string[] = []) {
 }
 
 export function componentSlugs() {
-  let slugs = getComponentSlugs().map((slug) => slug.replace(/\.mdx$/, ''))
+  let components = getComponents(['slug', 'category'])
 
-  return slugs.map((slug) => {
+  return components.map(({ slug, category }) => {
     return {
       params: {
+        category,
         slug,
       },
     }

--- a/pages/components/[category]/[slug].tsx
+++ b/pages/components/[category]/[slug].tsx
@@ -5,12 +5,12 @@ import Head from 'next/head'
 import { ToastContainer, toast } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
 
-import ToastContext from '../../context/toast'
+import ToastContext from '../../../context/toast'
 
-import { Component } from '../../interface/component'
-import { FrontMatter } from '../../interface/frontmatter'
+import { Component } from '../../../interface/component'
+import { FrontMatter } from '../../../interface/frontmatter'
 
-import { componentSlugs } from '../../lib/components'
+import { componentSlugs } from '../../../lib/components'
 
 import fs from 'fs'
 import path from 'path'
@@ -18,7 +18,7 @@ import matter from 'gray-matter'
 import { MDXRemote } from 'next-mdx-remote'
 import { serialize } from 'next-mdx-remote/serialize'
 
-import List from '../../components/collection/list'
+import List from '../../../components/collection/list'
 
 const components = {
   List,


### PR DESCRIPTION
This PR adds nested collections to HyperUI which will change routes like so:

```js
'/components/alerts'  = '/components/marketing/alerts'
'/components/product-cards' = '/components/ecommerce/product-cards'

// ... and so on
```