### PR TITLE
fix/site/broken-hyperjs-link

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -57,7 +57,7 @@ function MyApp({ Component, pageProps }: AppProps) {
 
       <Popup
         text="Use Alpine JS? Click Here 👋"
-        url="https://alpinejs.hyperui.dev"
+        url="https://hyperjs.dev/"
       />
 
       <Header />


### PR DESCRIPTION
the popup pointed to https://alpinejs.hyperui.dev which is broken.

![image](https://user-images.githubusercontent.com/68690233/176903227-63be4782-c6ed-4d2d-a551-85b24cebbf12.png)
