### PR TITLE
Update hacktoberfest-2022.mdx

### DIFF
--- a/src/data/posts/hacktoberfest-2022.mdx
+++ b/src/data/posts/hacktoberfest-2022.mdx
@@ -8,7 +8,7 @@ tags: [hacktoberfest, tailwindcss]
 
 I'm pleased to announce that HyperUI will be participating in [Hacktoberfest 2022](https://hacktoberfest.com).
 
-Before creating PRs, it's worth reading through [How to Contribute to HyperUI](/blog/how-to-contribute) as well as the [Hacktoberfest Participation Guide](https://hacktoberfest.com/participation/).
+Before creating PRs, it's worth reading through [How to Contribute to HyperUI](https://github.com/markmead/hyperui/blob/main/src/data/posts/how-to-contribute.mdx) as well as the [Hacktoberfest Participation Guide](https://hacktoberfest.com/participation/).
 
 All PRs will need to be up-to the standard of previous PRs on the HyperUI project, it would be worth spending a few minutes reviewing what other contributors have done.
 


### PR DESCRIPTION
Updated "How to contribute" URL. Earlier it was giving 404 error.

**Describe Changes**
Earlier URL was 'https://github.com/markmead/hyperui/blob/main/blog/how-to-contribute'. It was showing 404 error.
U[dated URL: 'https://github.com/markmead/hyperui/blob/main/src/data/posts/how-to-contribute.mdx'