### PR TITLE
Hotfix - Incorrect component description

### DIFF
--- a/src/data/components/marketing-navigations.mdx
+++ b/src/data/components/marketing-navigations.mdx
@@ -25,9 +25,9 @@ components:
   4:
     title: With Links, Basket, Account and Search
   5:
-    title: With Links and Actions
-  6:
     title: With Search, Links and Actions
+  6:
+    title: With Links and Actions
   7:
     title: Contained with Links
 ---


### PR DESCRIPTION
The rendered examples are swapped: `With Links and Actions <-> With Search, Links and Actions`.
See: https://www.hyperui.dev/components/marketing/navigations#component-6

> NOTE: Sorry for the PR without issue first. Also, not tested locally because I'm not on my machine at moment. I can do the full process described in the [how-to-contribute](https://www.hyperui.dev/blog/how-to-contribute) page when I get home. I just decided to "give it a try" by quick checking via Vercel preview feature ;)