### PR TITLE
Feature - Add redirects for removed blogs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -28,6 +28,16 @@ module.exports = {
         destination: '/components/application-ui',
         permanent: true,
       },
+      {
+        source: '/blog/whats-new-in-hyperui',
+        destination: '/blog',
+        permanent: true,
+      },
+      {
+        source: '/blog/hyperui-rewrite-whats-changed',
+        destination: '/blog',
+        permanent: true,
+      },
     ]
   },
 }


### PR DESCRIPTION
Some blogs were removed on a recent update, this redirects those routes back to `/blog`.