### PR TITLE
Hotfix - Revert 2x2 collection grid

### DIFF
--- a/src/components/CollectionGrid.jsx
+++ b/src/components/CollectionGrid.jsx
@@ -2,7 +2,7 @@ import CollectionCard from '@component/CollectionCard'
 
 export default function CollectionGrid({ componentItems }) {
   return (
-    <ul className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+    <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
       {componentItems.map((componentData) => (
         <li key={componentData.slug}>
           <CollectionCard componentData={componentData} />


### PR DESCRIPTION
Small fix to the `CollectionGrid.jsx` component to change it back to a stacked layout on mobile instead of a 2x2 grid.