### PR TITLE
Feature - New `<select>` components

### DIFF
--- a/public/components/application-ui-selects/1.html
+++ b/public/components/application-ui-selects/1.html
@@ -1,0 +1,20 @@
+<div>
+  <label for="HeadlineAct" class="block text-sm font-medium text-gray-900">
+    Headliner
+  </label>
+
+  <select
+    name="HeadlineAct"
+    id="HeadlineAct"
+    class="mt-1.5 w-full rounded-lg border-gray-300 text-gray-700 sm:text-sm"
+  >
+    <option value="">Please select</option>
+    <option value="JM">John Mayer</option>
+    <option value="SRV">Stevie Ray Vaughn</option>
+    <option value="JH">Jimi Hendrix</option>
+    <option value="BBK">B.B King</option>
+    <option value="AK">Albert King</option>
+    <option value="BG">Buddy Guy</option>
+    <option value="EC">Eric Clapton</option>
+  </select>
+</div>

--- a/public/components/application-ui-selects/2.html
+++ b/public/components/application-ui-selects/2.html
@@ -1,0 +1,34 @@
+<div>
+  <label for="HeadlineAct" class="block text-sm font-medium text-gray-900">
+    Headliner
+  </label>
+
+  <select
+    name="HeadlineAct"
+    id="HeadlineAct"
+    class="mt-1.5 w-full rounded-lg border-gray-300 text-gray-700 sm:text-sm"
+  >
+    <option value="">Please select</option>
+    <optgroup label="A">
+      <option value="AK">Albert King</option>
+    </optgroup>
+
+    <optgroup label="B">
+      <option value="BBK">B.B King</option>
+      <option value="BG">Buddy Guy</option>
+    </optgroup>
+
+    <optgroup label="E">
+      <option value="EC">Eric Clapton</option>
+    </optgroup>
+
+    <optgroup label="J">
+      <option value="JM">John Mayer</option>
+      <option value="JH">Jimi Hendrix</option>
+    </optgroup>
+
+    <optgroup label="S">
+      <option value="SRV">Stevie Ray Vaughn</option>
+    </optgroup>
+  </select>
+</div>

--- a/public/components/application-ui-selects/3.html
+++ b/public/components/application-ui-selects/3.html
@@ -1,0 +1,42 @@
+<div>
+  <label for="HeadlineAct" class="block text-sm font-medium text-gray-900">
+    Headliner
+  </label>
+
+  <div class="relative mt-1.5">
+    <input
+      type="text"
+      list="HeadlineActArtist"
+      id="HeadlineAct"
+      class="w-full rounded-lg border-gray-300 pr-10 text-gray-700 sm:text-sm [&::-webkit-calendar-picker-indicator]:opacity-0"
+      placeholder="Please select"
+    />
+
+    <span class="absolute inset-y-0 right-0 flex w-8 items-center">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="1.5"
+        stroke="currentColor"
+        class="h-5 w-5 text-gray-500"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M8.25 15L12 18.75 15.75 15m-7.5-6L12 5.25 15.75 9"
+        />
+      </svg>
+    </span>
+  </div>
+
+  <datalist name="HeadlineAct" id="HeadlineActArtist">
+    <option value="JM">John Mayer</option>
+    <option value="SRV">Stevie Ray Vaughn</option>
+    <option value="JH">Jimi Hendrix</option>
+    <option value="BBK">B.B King</option>
+    <option value="AK">Albert King</option>
+    <option value="BG">Buddy Guy</option>
+    <option value="EC">Eric Clapton</option>
+  </datalist>
+</div>

--- a/src/data/components/application-ui-selects.mdx
+++ b/src/data/components/application-ui-selects.mdx
@@ -1,0 +1,25 @@
+---
+title: Selects
+emoji: 📣
+category: application-ui
+container: max-w-xs mx-auto p-4 sm:p-6 lg:p-8
+seo:
+  title: Select Components
+  description: Select components created with Tailwind CSS
+components:
+  1:
+    title: Base
+  2:
+    title: Base with Groups
+  3:
+    title: Datalist
+---
+
+# Select Components
+
+These use the native `<select>` elements. In the future, we should be able to apply a more custom look and feel. Based on [Google I/O CSS Update](https://developer.chrome.com/blog/whats-new-css-ui-2023/#selectmenu).
+
+<CollectionList
+  componentsData={componentsData}
+  componentContainer={componentContainer}
+/>


### PR DESCRIPTION
PR to add native `<select>` components including a `<datalist>` example.

In the future we should be able to make a more custom look/feel to `<select>` elements 🤞

---

This PR has some leftover work that needed removing from a previous PR.