### PR TITLE
Hotfix - Replace `tabindex` with `tabIndex` for JSX

### DIFF
--- a/src/utils/transformers.js
+++ b/src/utils/transformers.js
@@ -41,6 +41,7 @@ export function componentPreviewJsx(componentHtml) {
   clonedHtml = clonedHtml.replace(/stroke-dashoffset=/g, 'strokeDashoffset=')
   clonedHtml = clonedHtml.replace(/stroke-miterlimit=/g, 'strokeMiterlimit=')
   clonedHtml = clonedHtml.replace(/stroke-opacity=/g, 'strokeOpacity=')
+  clonedHtml = clonedHtml.replace(/tabindex=/g, 'tabIndex=')
   clonedHtml = clonedHtml.replace(/<!--/g, '{/*')
   clonedHtml = clonedHtml.replace(/-->/g, '*/}')
 


### PR DESCRIPTION
Fixes #322 