### PR TITLE
Hotfix - Disable data cache

### DIFF
--- a/src/components/BlogPreview.jsx
+++ b/src/components/BlogPreview.jsx
@@ -43,7 +43,7 @@ export default function BlogPreview({ previewId, previewTitle, previewContainer 
   async function fetchHtml() {
     const previewUrl = `/blogs/${previewId}.html`
 
-    const fetchResponse = await fetch(previewUrl)
+    const fetchResponse = await fetch(previewUrl, { cache: 'no-store' })
     const textResponse = await fetchResponse.text()
     const transformedHtml = blogPreviewHtml(textResponse, previewContainer, isDarkMode)
 

--- a/src/components/ComponentPreview.jsx
+++ b/src/components/ComponentPreview.jsx
@@ -108,7 +108,7 @@ export default function ComponentPreview({ componentData, componentContainer }) 
 
     const componentUrl = `/components/${componentCategory}-${componentSlug}/${componentPath}.html`
 
-    const fetchResponse = await fetch(componentUrl)
+    const fetchResponse = await fetch(componentUrl, { cache: 'no-store' })
     const textResponse = await fetchResponse.text()
     const transformedHtml = componentPreviewHtml(
       textResponse,

--- a/src/components/HeaderSearch.jsx
+++ b/src/components/HeaderSearch.jsx
@@ -60,7 +60,7 @@ export default function HeaderSearch() {
   useDebounce(() => setSearchQueryDebounced(searchQuery), 500, [searchQuery])
 
   async function fetchSearchResults() {
-    const searchResults = await fetch('/api/search')
+    const searchResults = await fetch('/api/search', { cache: 'no-store' })
     const searchJson = await searchResults.json()
 
     return searchJson


### PR DESCRIPTION
Like many others, I received an email from Vercel indicating potential issues with their new pricing structure. It seems the root of the problem lies with the data cache, a feature I didn't knowingly opt into but appears to be the default when using the app router.

From what I understand, adding `{ cache: 'no-store' }` to the site's fetch requests should eliminate cache usage. This seems beneficial for a few reasons:

- It should prohibit modifications to the Vercel tier.
- Components will remain up-to-date.

Clearly, the drawback is a slower fetch request, but hopefully, it's nothing too severe. If necessary, I can always adjust the settings.

I don't suppose you could confirm that this would address the usage issue with my account, @leerob?