### PR TITLE
Feature - Rotate ads

### DIFF
--- a/app/[components]/[category]/[collection]/page.jsx
+++ b/app/[components]/[category]/[collection]/page.jsx
@@ -104,7 +104,7 @@ export default async function Page({ params }) {
         />
       </div>
 
-      <Ad isCenter adStyle="stickybox" />
+      <Ad isCenter />
     </Container>
   )
 }

--- a/app/about/[slug]/page.jsx
+++ b/app/about/[slug]/page.jsx
@@ -79,7 +79,7 @@ export default async function Page({ params }) {
         <MdxRemoteRender mdxSource={pageContent} mdxComponents={mdxComponents} />
       </article>
 
-      <Ad isCenter adStyle="stickybox" />
+      <Ad isCenter />
     </Container>
   )
 }

--- a/app/ads.js
+++ b/app/ads.js
@@ -3,15 +3,36 @@
 import { useEffect } from 'react'
 import { usePathname } from 'next/navigation'
 
+import { useInterval } from 'react-use'
+
 export default function Ads() {
   const routerPathname = usePathname()
 
   useEffect(() => {
+    loadAd()
+  }, [routerPathname])
+
+  useInterval(() => {
+    loadAd()
+  }, 30000)
+
+  useEffect(() => {
+    document.addEventListener('preview:clicked', loadAd)
+  }, [])
+
+  function loadAd() {
+    if (document.getElementById('EthicalAds')) {
+      window && window.ethicalads && window.ethicalads.reload()
+
+      return
+    }
+
     const newScript = document.createElement('script')
 
     newScript.src = 'https://media.ethicalads.io/media/client/ethicalads.min.js'
     newScript.async = true
+    newScript.id = 'EthicalAds'
 
     document.body.appendChild(newScript)
-  }, [routerPathname])
+  }
 }

--- a/app/blog/[slug]/page.jsx
+++ b/app/blog/[slug]/page.jsx
@@ -100,7 +100,7 @@ export default async function Page({ params }) {
           <MdxRemoteRender mdxSource={blogContent} mdxComponents={mdxComponents} />
         </article>
 
-        <Ad isCenter adStyle="stickybox" />
+        <Ad isCenter />
       </Container>
     </>
   )

--- a/src/components/Ad.jsx
+++ b/src/components/Ad.jsx
@@ -1,10 +1,10 @@
-export default function Ad({ adStyle, isCenter = false }) {
+export default function Ad({ isCenter = false }) {
   return (
     <div className={`not-prose max-w-lg ${isCenter && 'mx-auto text-center'}`}>
       <div
         data-ea-publisher="hyperuidev"
         data-ea-type="image"
-        data-ea-style={adStyle}
+        data-ea-style="stickybox"
         className="bordered horizontal [&_.ea-callout]:!mb-0 [&_.ea-content]:!mx-0 [&_.ea-content]:!mt-0 [&_.ea-stickybox-hide]:hidden"
       ></div>
     </div>

--- a/src/components/PreviewTitle.jsx
+++ b/src/components/PreviewTitle.jsx
@@ -1,12 +1,16 @@
-import { sendGAEvent } from '@next/third-parties/google'
-
 export default function PreviewTitle({ componentTitle, componentHash }) {
+  function handleClick() {
+    const clickEvent = new Event('preview:clicked')
+
+    document.dispatchEvent(clickEvent)
+  }
+
   return (
     <h2 className="text-xl font-bold text-gray-900 sm:text-2xl">
       <a
         href={`#${componentHash}`}
         className="group relative inline-block"
-        onClick={() => sendGAEvent({ event: 'component_title_clicked' })}
+        onClick={() => handleClick()}
       >
         <span
           aria-hidden="true"


### PR DESCRIPTION
Reading through the EthicalAds docs, it seems that you can rotate ads every 30s, or when the hash changes in the URL. Just giving this a try to see how it works.

Also managed to fix the bug where EthicalAds loads in twice.