### PR TITLE
Hotfix - Screen reader label from pagination

### DIFF
--- a/public/components/application-ui-pagination/4-dark.html
+++ b/public/components/application-ui-pagination/4-dark.html
@@ -3,7 +3,7 @@
     href="#"
     class="inline-flex size-8 items-center justify-center rounded border border-gray-100 bg-white text-gray-900 rtl:rotate-180 dark:border-gray-800 dark:bg-gray-900 dark:text-white"
   >
-    <span class="sr-only">Next Page</span>
+    <span class="sr-only">Prev Page</span>
     <svg xmlns="http://www.w3.org/2000/svg" class="size-3" viewBox="0 0 20 20" fill="currentColor">
       <path
         fill-rule="evenodd"

--- a/public/components/application-ui-pagination/4.html
+++ b/public/components/application-ui-pagination/4.html
@@ -3,7 +3,7 @@
     href="#"
     class="inline-flex size-8 items-center justify-center rounded border border-gray-100 bg-white text-gray-900 rtl:rotate-180"
   >
-    <span class="sr-only">Next Page</span>
+    <span class="sr-only">Prev Page</span>
     <svg xmlns="http://www.w3.org/2000/svg" class="size-3" viewBox="0 0 20 20" fill="currentColor">
       <path
         fill-rule="evenodd"


### PR DESCRIPTION
This PR addresses an accessibility issue in the pagination component. The screen reader text (sr-only) for the "Prev Page" button was incorrectly labeled as "Next Page," which could lead to confusion for users relying on screen readers.

#489 