### PR TITLE
Hotfix - Media component align stretch when flipped

### DIFF
--- a/public/components/application-ui-media/8.html
+++ b/public/components/application-ui-media/8.html
@@ -2,7 +2,7 @@
   <img
     src="https://images.unsplash.com/photo-1633332755192-727a05c4013d?q=80&w=2680&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
     alt=""
-    class="size-20 rounded-lg object-cover"
+    class="aspect-square w-20 rounded-lg object-cover"
   />
 
   <div>


### PR DESCRIPTION
## Description:
This PR addresses the alignment issue in the last component of the Media Components section on the hyperui.dev website. The image, title, content, and flipped, were improperly aligned, causing them not to stretch as expected.

Fixes: #507 

## Changes Made:
- Adjusted Tailwind CSS properties to ensure properly stretched and align.
- Ensured that the image stretches correctly to match the intended design.

## Steps to Test:
1.  Navigate to https://www.hyperui.dev/components/application-ui/media
2. Scroll to the last component of the media section.
3. Verify that the image, title, and content are now correctly aligned and that the image stretches as expected.

## Preview:
![Screenshot 2024-10-07 233143](https://github.com/user-attachments/assets/bf0e24a7-9e42-418a-99c0-9f3e2dce527d)
