### PR TITLE
Feature - New breadcrumb component

### DIFF
--- a/public/components/application-ui-breadcrumbs/2-dark.html
+++ b/public/components/application-ui-breadcrumbs/2-dark.html
@@ -4,15 +4,12 @@
   This component comes with some `rtl` classes. Please remove them if they are not needed in your project.
 -->
 
-<nav aria-label="Breadcrumb" class="flex">
-  <ol
-    class="flex overflow-hidden rounded-lg border border-gray-200 text-gray-700 dark:border-gray-700 dark:text-gray-200"
-  >
-    <li class="flex items-center">
-      <a
-        href="#"
-        class="flex h-10 items-center gap-1.5 bg-gray-100 px-4 transition hover:text-gray-900 dark:bg-gray-800 dark:hover:text-white"
-      >
+<nav aria-label="Breadcrumb">
+  <ol class="flex items-center gap-1 text-sm text-gray-600 dark:text-gray-300">
+    <li>
+      <a href="#" class="block transition hover:text-gray-700 dark:hover:text-gray-200">
+        <span class="sr-only"> Home </span>
+
         <svg
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
@@ -27,22 +24,42 @@
             d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
           />
         </svg>
-
-        <span class="text-xs font-medium"> Home </span>
       </a>
     </li>
 
-    <li class="relative flex items-center">
-      <span
-        class="absolute inset-y-0 -start-px h-10 w-4 bg-gray-100 [clip-path:_polygon(0_0,_0%_100%,_100%_50%)] rtl:rotate-180 dark:bg-gray-800"
+    <li class="rtl:rotate-180">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="1.5"
+        stroke="currentColor"
+        class="size-4"
       >
-      </span>
+        <path stroke-linecap="round" stroke-linejoin="round" d="m9 20.247 6-16.5" />
+      </svg>
+    </li>
 
-      <a
-        href="#"
-        class="flex h-10 items-center bg-white pe-4 ps-8 text-xs font-medium transition hover:text-gray-900 dark:bg-gray-900 dark:hover:text-white"
+    <li>
+      <a href="#" class="block transition hover:text-gray-700 dark:hover:text-gray-200"> Shirts </a>
+    </li>
+
+    <li class="rtl:rotate-180">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="1.5"
+        stroke="currentColor"
+        class="size-4"
       >
-        Shirts
+        <path stroke-linecap="round" stroke-linejoin="round" d="m9 20.247 6-16.5" />
+      </svg>
+    </li>
+
+    <li>
+      <a href="#" class="block transition hover:text-gray-700 dark:hover:text-gray-200">
+        Plain Tee
       </a>
     </li>
   </ol>

--- a/public/components/application-ui-breadcrumbs/2.html
+++ b/public/components/application-ui-breadcrumbs/2.html
@@ -4,13 +4,12 @@
   This component comes with some `rtl` classes. Please remove them if they are not needed in your project.
 -->
 
-<nav aria-label="Breadcrumb" class="flex">
-  <ol class="flex overflow-hidden rounded-lg border border-gray-200 text-gray-600">
-    <li class="flex items-center">
-      <a
-        href="#"
-        class="flex h-10 items-center gap-1.5 bg-gray-100 px-4 transition hover:text-gray-900"
-      >
+<nav aria-label="Breadcrumb">
+  <ol class="flex items-center gap-1 text-sm text-gray-600">
+    <li>
+      <a href="#" class="block transition hover:text-gray-700">
+        <span class="sr-only"> Home </span>
+
         <svg
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
@@ -25,23 +24,41 @@
             d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
           />
         </svg>
-
-        <span class="ms-1.5 text-xs font-medium"> Home </span>
       </a>
     </li>
 
-    <li class="relative flex items-center">
-      <span
-        class="absolute inset-y-0 -start-px h-10 w-4 bg-gray-100 [clip-path:_polygon(0_0,_0%_100%,_100%_50%)] rtl:rotate-180"
+    <li class="rtl:rotate-180">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="1.5"
+        stroke="currentColor"
+        class="size-4"
       >
-      </span>
+        <path stroke-linecap="round" stroke-linejoin="round" d="m9 20.247 6-16.5" />
+      </svg>
+    </li>
 
-      <a
-        href="#"
-        class="flex h-10 items-center bg-white pe-4 ps-8 text-xs font-medium transition hover:text-gray-900"
+    <li>
+      <a href="#" class="block transition hover:text-gray-700"> Shirts </a>
+    </li>
+
+    <li class="rtl:rotate-180">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="1.5"
+        stroke="currentColor"
+        class="size-4"
       >
-        Shirts
-      </a>
+        <path stroke-linecap="round" stroke-linejoin="round" d="m9 20.247 6-16.5" />
+      </svg>
+    </li>
+
+    <li>
+      <a href="#" class="block transition hover:text-gray-700"> Plain Tee </a>
     </li>
   </ol>
 </nav>

--- a/public/components/application-ui-breadcrumbs/3-dark.html
+++ b/public/components/application-ui-breadcrumbs/3-dark.html
@@ -1,0 +1,37 @@
+<nav aria-label="Breadcrumb">
+  <ol class="flex items-center gap-1 text-sm text-gray-600 dark:text-gray-300">
+      <li>
+          <a href="#" class="block transition hover:text-gray-700 dark:hover:text-gray-200">
+              <span class="sr-only"> Home </span>
+
+              <svg xmlns="http://www.w3.org/2000/svg" class="size-4" fill="none" viewBox="0 0 24 24"
+                  stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                      d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+              </svg>
+          </a>
+      </li>
+
+      <li class="rtl:rotate-180">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
+              class="size-4">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m9 20.247 6-16.5" />
+          </svg>
+      </li>
+
+      <li>
+          <a href="#" class="block transition hover:text-gray-700 dark:hover:text-gray-200"> Shirts </a>
+      </li>
+
+      <li class="rtl:rotate-180">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
+              class="size-4">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m9 20.247 6-16.5" />
+          </svg>
+      </li>
+
+      <li>
+          <a href="#" class="block transition hover:text-gray-700 dark:hover:text-gray-200"> Plain Tee </a>
+      </li>
+  </ol>
+</nav>

--- a/public/components/application-ui-breadcrumbs/3-dark.html
+++ b/public/components/application-ui-breadcrumbs/3-dark.html
@@ -1,37 +1,49 @@
-<nav aria-label="Breadcrumb">
-  <ol class="flex items-center gap-1 text-sm text-gray-600 dark:text-gray-300">
-      <li>
-          <a href="#" class="block transition hover:text-gray-700 dark:hover:text-gray-200">
-              <span class="sr-only"> Home </span>
+<!--
+  Heads up! 👋
 
-              <svg xmlns="http://www.w3.org/2000/svg" class="size-4" fill="none" viewBox="0 0 24 24"
-                  stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                      d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-              </svg>
-          </a>
-      </li>
+  This component comes with some `rtl` classes. Please remove them if they are not needed in your project.
+-->
 
-      <li class="rtl:rotate-180">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
-              class="size-4">
-              <path stroke-linecap="round" stroke-linejoin="round" d="m9 20.247 6-16.5" />
-          </svg>
-      </li>
+<nav aria-label="Breadcrumb" class="flex">
+  <ol
+    class="flex overflow-hidden rounded-lg border border-gray-200 text-gray-700 dark:border-gray-700 dark:text-gray-200"
+  >
+    <li class="flex items-center">
+      <a
+        href="#"
+        class="flex h-10 items-center gap-1.5 bg-gray-100 px-4 transition hover:text-gray-900 dark:bg-gray-800 dark:hover:text-white"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="size-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+          />
+        </svg>
 
-      <li>
-          <a href="#" class="block transition hover:text-gray-700 dark:hover:text-gray-200"> Shirts </a>
-      </li>
+        <span class="text-xs font-medium"> Home </span>
+      </a>
+    </li>
 
-      <li class="rtl:rotate-180">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
-              class="size-4">
-              <path stroke-linecap="round" stroke-linejoin="round" d="m9 20.247 6-16.5" />
-          </svg>
-      </li>
+    <li class="relative flex items-center">
+      <span
+        class="absolute inset-y-0 -start-px h-10 w-4 bg-gray-100 [clip-path:_polygon(0_0,_0%_100%,_100%_50%)] rtl:rotate-180 dark:bg-gray-800"
+      >
+      </span>
 
-      <li>
-          <a href="#" class="block transition hover:text-gray-700 dark:hover:text-gray-200"> Plain Tee </a>
-      </li>
+      <a
+        href="#"
+        class="flex h-10 items-center bg-white pe-4 ps-8 text-xs font-medium transition hover:text-gray-900 dark:bg-gray-900 dark:hover:text-white"
+      >
+        Shirts
+      </a>
+    </li>
   </ol>
 </nav>

--- a/public/components/application-ui-breadcrumbs/3.html
+++ b/public/components/application-ui-breadcrumbs/3.html
@@ -1,37 +1,47 @@
-<nav aria-label="Breadcrumb">
-  <ol class="flex items-center gap-1 text-sm text-gray-600">
-      <li>
-          <a href="#" class="block transition hover:text-gray-700">
-              <span class="sr-only"> Home </span>
+<!--
+  Heads up! 👋
 
-              <svg xmlns="http://www.w3.org/2000/svg" class="size-4" fill="none" viewBox="0 0 24 24"
-                  stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                      d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-              </svg>
-          </a>
-      </li>
+  This component comes with some `rtl` classes. Please remove them if they are not needed in your project.
+-->
 
-      <li class="rtl:rotate-180">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
-              class="size-4">
-              <path stroke-linecap="round" stroke-linejoin="round" d="m9 20.247 6-16.5" />
-          </svg>
-      </li>
+<nav aria-label="Breadcrumb" class="flex">
+  <ol class="flex overflow-hidden rounded-lg border border-gray-200 text-gray-600">
+    <li class="flex items-center">
+      <a
+        href="#"
+        class="flex h-10 items-center gap-1.5 bg-gray-100 px-4 transition hover:text-gray-900"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="size-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+          />
+        </svg>
 
-      <li>
-          <a href="#" class="block transition hover:text-gray-700"> Shirts </a>
-      </li>
+        <span class="ms-1.5 text-xs font-medium"> Home </span>
+      </a>
+    </li>
 
-      <li class="rtl:rotate-180">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
-              class="size-4">
-              <path stroke-linecap="round" stroke-linejoin="round" d="m9 20.247 6-16.5" />
-          </svg>
-      </li>
+    <li class="relative flex items-center">
+      <span
+        class="absolute inset-y-0 -start-px h-10 w-4 bg-gray-100 [clip-path:_polygon(0_0,_0%_100%,_100%_50%)] rtl:rotate-180"
+      >
+      </span>
 
-      <li>
-          <a href="#" class="block transition hover:text-gray-700"> Plain Tee </a>
-      </li>
+      <a
+        href="#"
+        class="flex h-10 items-center bg-white pe-4 ps-8 text-xs font-medium transition hover:text-gray-900"
+      >
+        Shirts
+      </a>
+    </li>
   </ol>
 </nav>

--- a/public/components/application-ui-breadcrumbs/3.html
+++ b/public/components/application-ui-breadcrumbs/3.html
@@ -1,0 +1,37 @@
+<nav aria-label="Breadcrumb">
+  <ol class="flex items-center gap-1 text-sm text-gray-600">
+      <li>
+          <a href="#" class="block transition hover:text-gray-700">
+              <span class="sr-only"> Home </span>
+
+              <svg xmlns="http://www.w3.org/2000/svg" class="size-4" fill="none" viewBox="0 0 24 24"
+                  stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                      d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+              </svg>
+          </a>
+      </li>
+
+      <li class="rtl:rotate-180">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
+              class="size-4">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m9 20.247 6-16.5" />
+          </svg>
+      </li>
+
+      <li>
+          <a href="#" class="block transition hover:text-gray-700"> Shirts </a>
+      </li>
+
+      <li class="rtl:rotate-180">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
+              class="size-4">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m9 20.247 6-16.5" />
+          </svg>
+      </li>
+
+      <li>
+          <a href="#" class="block transition hover:text-gray-700"> Plain Tee </a>
+      </li>
+  </ol>
+</nav>

--- a/src/data/components/application-ui-breadcrumbs.mdx
+++ b/src/data/components/application-ui-breadcrumbs.mdx
@@ -4,6 +4,7 @@ emoji: 🍞
 category: application-ui
 container: p-6 flex justify-center
 wrapper: h-[300px]
+tag: updated
 seo:
   title: Breadcrumb Components
   description: Breadcrumb components created with Tailwind CSS
@@ -12,12 +13,12 @@ components:
     title: Home icon and links, split with chevron
     dark: true
   2:
-    title: Home and links, split with chevron background
-    dark: true
-  3:
-    title: Home and links, split with slash
+    title: Home icon and links, split with slash
     dark: true
     creator: mohdahsanrazakhan
+  3:
+    title: Home and links, split with chevron background
+    dark: true
 ---
 
 # Breadcrumb Components

--- a/src/data/components/application-ui-breadcrumbs.mdx
+++ b/src/data/components/application-ui-breadcrumbs.mdx
@@ -14,6 +14,10 @@ components:
   2:
     title: Home and links, split with chevron background
     dark: true
+  3:
+    title: Home and links, split with slash
+    dark: true
+    creator: mohdahsanrazakhan
 ---
 
 # Breadcrumb Components

--- a/src/data/components/marketing-product-cards.mdx
+++ b/src/data/components/marketing-product-cards.mdx
@@ -3,7 +3,6 @@ title: Product Cards
 emoji: 🙋‍♀️
 category: marketing
 container: p-6 max-w-md mx-auto
-tag: new
 seo:
   title: Product Card Components
   description: Product card components created with Tailwind CSS


### PR DESCRIPTION
# What does this PR do?
This PR adds a new feature to the Breadcrumb Component. The updated breadcrumb includes details such as home, links, separated by slashes.

Fixes: #525

# Preview:
Light:

![image](https://github.com/user-attachments/assets/4e14556f-9f46-4e64-b01a-70bf9d00f5ad)

Dark:
![image](https://github.com/user-attachments/assets/a17dbd29-a133-4317-a4dc-3684ec2f9fa4)
