### PR TITLE
Feature - Tooltip/popover collection

### DIFF
--- a/public/components/application/tooltips/1-dark.html
+++ b/public/components/application/tooltips/1-dark.html
@@ -1,0 +1,16 @@
+<button
+  popovertarget="Tooltip"
+  popovertargetaction="toggle"
+  class="font-medium text-gray-900 underline underline-offset-2 dark:text-white"
+  aria-describedby="Tooltip"
+>
+  Help?
+</button>
+
+<div
+  id="Tooltip"
+  popover="auto"
+  class="mt-1.5 max-w-sm rounded border border-gray-300 bg-gray-50 p-3 text-gray-900 shadow-sm [position-area:_bottom] dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+>
+  Lorem, ipsum dolor sit amet consectetur adipisicing elit. Asperiores, cumque!
+</div>

--- a/public/components/application/tooltips/1.html
+++ b/public/components/application/tooltips/1.html
@@ -1,0 +1,16 @@
+<button
+  popovertarget="Tooltip"
+  popovertargetaction="toggle"
+  class="font-medium text-gray-900 underline underline-offset-2"
+  aria-describedby="Tooltip"
+>
+  Help?
+</button>
+
+<div
+  id="Tooltip"
+  popover="auto"
+  class="mt-1.5 max-w-sm rounded border border-gray-300 bg-gray-50 p-3 text-gray-900 shadow-sm [position-area:_bottom]"
+>
+  Lorem, ipsum dolor sit amet consectetur adipisicing elit. Asperiores, cumque!
+</div>

--- a/public/components/application/tooltips/2-dark.html
+++ b/public/components/application/tooltips/2-dark.html
@@ -1,0 +1,16 @@
+<button
+  popovertarget="Tooltip"
+  popovertargetaction="toggle"
+  class="font-medium text-gray-900 underline underline-offset-2 dark:text-white"
+  aria-describedby="Tooltip"
+>
+  Help?
+</button>
+
+<div
+  id="Tooltip"
+  popover="auto"
+  class="mt-1.5 max-w-sm rounded border border-gray-300 bg-gray-50 p-3 text-gray-900 shadow-sm transition-opacity duration-300 [position-area:_bottom] dark:border-gray-600 dark:bg-gray-800 dark:text-white starting:opacity-0 starting:open:opacity-0"
+>
+  Lorem, ipsum dolor sit amet consectetur adipisicing elit. Asperiores, cumque!
+</div>

--- a/public/components/application/tooltips/2.html
+++ b/public/components/application/tooltips/2.html
@@ -1,0 +1,16 @@
+<button
+  popovertarget="Tooltip"
+  popovertargetaction="toggle"
+  class="font-medium text-gray-900 underline underline-offset-2"
+  aria-describedby="Tooltip"
+>
+  Help?
+</button>
+
+<div
+  id="Tooltip"
+  popover="auto"
+  class="mt-1.5 max-w-sm rounded border border-gray-300 bg-gray-50 p-3 text-gray-900 shadow-sm transition-opacity duration-300 [position-area:_bottom] starting:opacity-0 starting:open:opacity-0"
+>
+  Lorem, ipsum dolor sit amet consectetur adipisicing elit. Asperiores, cumque!
+</div>

--- a/public/components/application/tooltips/3-dark.html
+++ b/public/components/application/tooltips/3-dark.html
@@ -1,0 +1,15 @@
+<span class="group relative">
+  <button
+    class="font-medium text-gray-900 underline underline-offset-2 dark:text-white"
+    aria-describedby="Tooltip"
+  >
+    Help?
+  </button>
+
+  <div
+    id="Tooltip"
+    class="invisible absolute left-1/2 mt-1.5 w-max max-w-sm -translate-x-1/2 rounded border border-gray-300 bg-gray-50 p-3 text-gray-900 shadow-sm group-hover:visible dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+  >
+    Lorem, ipsum dolor sit amet consectetur adipisicing elit. Asperiores, cumque!
+  </div>
+</span>

--- a/public/components/application/tooltips/3.html
+++ b/public/components/application/tooltips/3.html
@@ -1,0 +1,12 @@
+<span class="group relative">
+  <button class="font-medium text-gray-900 underline underline-offset-2" aria-describedby="Tooltip">
+    Help?
+  </button>
+
+  <div
+    id="Tooltip"
+    class="invisible absolute left-1/2 mt-1.5 w-max max-w-sm -translate-x-1/2 rounded border border-gray-300 bg-gray-50 p-3 text-gray-900 shadow-sm group-hover:visible"
+  >
+    Lorem, ipsum dolor sit amet consectetur adipisicing elit. Asperiores, cumque!
+  </div>
+</span>

--- a/public/components/application/tooltips/4-dark.html
+++ b/public/components/application/tooltips/4-dark.html
@@ -1,0 +1,15 @@
+<span class="group relative">
+  <button
+    class="font-medium text-gray-900 underline underline-offset-2 dark:text-white"
+    aria-describedby="Tooltip"
+  >
+    Help?
+  </button>
+
+  <div
+    id="Tooltip"
+    class="absolute left-1/2 mt-1.5 w-max max-w-sm -translate-x-1/2 rounded border border-gray-300 bg-gray-50 p-3 text-gray-900 opacity-0 shadow-sm transition-opacity duration-300 group-hover:opacity-100 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+  >
+    Lorem, ipsum dolor sit amet consectetur adipisicing elit. Asperiores, cumque!
+  </div>
+</span>

--- a/public/components/application/tooltips/4.html
+++ b/public/components/application/tooltips/4.html
@@ -1,0 +1,12 @@
+<span class="group relative">
+  <button class="font-medium text-gray-900 underline underline-offset-2" aria-describedby="Tooltip">
+    Help?
+  </button>
+
+  <div
+    id="Tooltip"
+    class="absolute left-1/2 mt-1.5 w-max max-w-sm -translate-x-1/2 rounded border border-gray-300 bg-gray-50 p-3 text-gray-900 opacity-0 shadow-sm transition-opacity duration-300 group-hover:opacity-100"
+  >
+    Lorem, ipsum dolor sit amet consectetur adipisicing elit. Asperiores, cumque!
+  </div>
+</span>

--- a/src/data/components/application/tooltips.mdx
+++ b/src/data/components/application/tooltips.mdx
@@ -1,0 +1,24 @@
+---
+title: Tooltips
+description: A collection of accessible tooltip and popover components using the new HTML popover attribute and Tailwind CSS. Includes native popovers for modern web applications.
+emoji: 💬
+container: p-6 max-w-md mx-auto
+tag: new
+terms:
+  - tooltip
+  - popover
+  - hint
+components:
+  - { title: 'Popover attribute', dark: true }
+  - { title: 'Popover attribute with animation', dark: true }
+  - { title: 'Base', dark: true }
+  - { title: 'Base with animation', dark: true }
+---
+
+# Tooltip Components
+
+<p>{frontmatter.description}</p>
+
+**Note:** The `popover` attribute is new and not yet widely supported. Check [Can I use](https://caniuse.com/?search=popover) for browser compatibility.
+
+<CollectionList componentsData={componentsData} />

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -132,6 +132,9 @@ export async function getCollection({ category, collection }) {
 
     const mdxSource = await serialize(componentItem, {
       parseFrontmatter: true,
+      mdxOptions: {
+        rehypePlugins: [[rehypeExternalLinks, { target: '_blank' }]],
+      },
     })
 
     return {


### PR DESCRIPTION
This pull request introduces a new collection of accessible tooltip and popover components, leveraging the HTML `popover` attribute and Tailwind CSS. It includes both light and dark mode variations, as well as animated and static options. Additionally, a new MDX file for documentation and a minor utility update were added.

### Tooltip Components Implementation:

* Added four tooltip variations (`1.html`, `2.html`, `3.html`, `4.html`) and their corresponding dark mode versions (`1-dark.html`, `2-dark.html`, `3-dark.html`, `4-dark.html`). These include static and animated tooltips, as well as hover-based visibility toggles. [[1]](diffhunk://#diff-b3466a49922ba3851973e540553e3efd668434518ed417c1803e061b970de649R1-R16) [[2]](diffhunk://#diff-0b5019a28f2b96aeb737ae4b216881886bd89303ba8982f1188a9af1295f7a76R1-R16) [[3]](diffhunk://#diff-beeb5e4229d7a539243918fc5d0977e72598552e67d0cae13b3708c1818b53a5R1-R16) [[4]](diffhunk://#diff-2b2a2e7ce71231a65b583d0ba353f69fa51f253e3f90c056a568b1872a288c67R1-R16) [[5]](diffhunk://#diff-2f28be59acf1a7a7965fc22184f84f49d3e7e381322ac741932a2a847d95520cR1-R15) [[6]](diffhunk://#diff-2c42f69b0af3618fa704cc78ca4eaf47aba1b17bb49063ab0ff6e63c1711e159R1-R12) [[7]](diffhunk://#diff-de33186cc7932b5e6a50c9bd188680f155f2b9db284bb52412531630cfd0d6f9R1-R15) [[8]](diffhunk://#diff-386d22816e58f5275653c4db0ccd4dc34ac62d3eff3b30445a2f0da04423f0bdR1-R12)

### Documentation:

* Created a new MDX file `tooltips.mdx` to document the tooltip components, including metadata, descriptions, and a compatibility note for the `popover` attribute.

### Utility Update:

* Updated `getCollection` function in `src/utils/db.js` to include the `rehypeExternalLinks` plugin for handling external links in serialized MDX content.