### PR TITLE
Feature - Add a hide marketing toggle

### DIFF
--- a/app/[components]/[category]/[collection]/page.jsx
+++ b/app/[components]/[category]/[collection]/page.jsx
@@ -87,7 +87,7 @@ export default async function Page({ params }) {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListSchema) }}
       />
 
-      <div className="prose prose-p:max-w-prose max-w-none">
+      <div className="prose prose-p:max-w-prose prose-p:stripped:hidden max-w-none">
         <MdxRemoteRender
           mdxSource={collectionContent}
           mdxComponents={mdxComponents}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint": "9.35.0",
     "eslint-config-next": "15.5.2",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-unicorn": "^61.0.1",
+    "eslint-plugin-unicorn": "^61.0.2",
     "fast-glob": "^3.3.3",
     "gray-matter": "^4.0.3",
     "next-mdx-remote": "^5.0.0",

--- a/src/components/BlogCard.jsx
+++ b/src/components/BlogCard.jsx
@@ -6,11 +6,11 @@ export default function BlogCard({ blogPost }) {
       href={`/blog/${blogPost.slug}`}
       className="block h-full rounded-lg border border-stone-300 bg-white p-4 shadow-sm transition-colors hover:border-indigo-500 hover:ring hover:ring-indigo-500 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none sm:p-6"
     >
-      <span aria-hidden="true" className="text-xl sm:text-2xl">
+      <span aria-hidden="true" className="stripped:hidden text-xl sm:text-2xl">
         {blogPost.emoji}
       </span>
 
-      <time className="mt-4 block text-sm text-stone-700">{blogPost.updated}</time>
+      <time className="stripped:mt-0 mt-4 block text-sm text-stone-700">{blogPost.updated}</time>
 
       <h2 className="mt-1 font-medium text-pretty text-stone-900 sm:text-lg">{blogPost.title}</h2>
     </Link>

--- a/src/components/CollectionCard.jsx
+++ b/src/components/CollectionCard.jsx
@@ -13,11 +13,11 @@ export default function CollectionCard({ componentData }) {
     >
       {hasTag && <CardTag tagType={componentData.tag} />}
 
-      <span aria-hidden="true" className="text-lg sm:text-xl">
+      <span aria-hidden="true" className="stripped:hidden text-lg sm:text-xl">
         {componentData.emoji}
       </span>
 
-      <p className="mt-4 block text-sm text-stone-700">{componentCount}</p>
+      <p className="stripped:mt-0 mt-4 block text-sm text-stone-700">{componentCount}</p>
 
       <h2 className="mt-1 font-medium text-pretty text-stone-900 sm:text-lg">
         {componentData.title}

--- a/src/components/PreviewBreakpoint.jsx
+++ b/src/components/PreviewBreakpoint.jsx
@@ -18,7 +18,10 @@ export default function PreviewBreakpoint({
         aria-label={descriptiveContent}
         aria-pressed={breakpointActive}
       >
-        <span aria-hidden="true">{breakpointEmoji}</span>
+        <span aria-hidden="true" className="stripped:hidden">
+          {breakpointEmoji}
+        </span>
+
         <span>{breakpointText}</span>
       </Button>
     </Tooltip>

--- a/src/components/PreviewCopy.jsx
+++ b/src/components/PreviewCopy.jsx
@@ -61,7 +61,10 @@ export default function PreviewCopy({ componentCode = '' }) {
           aria-describedby={liveRegionId}
           onClick={handleCopyToClipboard}
         >
-          <span aria-hidden="true">{buttonEmoji}</span>
+          <span aria-hidden="true" className="stripped:hidden">
+            {buttonEmoji}
+          </span>
+
           <span>{buttonText}</span>
         </Button>
       </Tooltip>

--- a/src/components/PreviewRtl.jsx
+++ b/src/components/PreviewRtl.jsx
@@ -11,7 +11,10 @@ export default function PreviewRtl({ isRtl, handleSetIsRtl }) {
         aria-pressed={isRtl}
         aria-label={descriptiveContent}
       >
-        <span aria-hidden="true">{isRtl ? '👈' : '👉'}</span>
+        <span aria-hidden="true" className="stripped:hidden">
+          {isRtl ? '👈' : '👉'}
+        </span>
+
         <span>{isRtl ? 'RTL' : 'LTR'}</span>
       </Button>
     </Tooltip>

--- a/src/components/PreviewView.jsx
+++ b/src/components/PreviewView.jsx
@@ -11,7 +11,10 @@ export default function PreviewView({ showPreview, handleSetShowPreview }) {
         aria-pressed={showPreview}
         aria-label={descriptiveContent}
       >
-        <span aria-hidden="true">{showPreview ? '👾' : '👀'}</span>
+        <span aria-hidden="true" className="stripped:hidden">
+          {showPreview ? '👾' : '👀'}
+        </span>
+
         <span>{showPreview ? 'Code' : 'View'}</span>
       </Button>
     </Tooltip>

--- a/src/components/global/Footer.jsx
+++ b/src/components/global/Footer.jsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 
 import Brand from '@component/global/Brand'
+import MarketingToggle from '@component/global/MarketingToggle'
 
 export default function Footer() {
   const footerLinks = [
@@ -16,15 +17,15 @@ export default function Footer() {
 
   return (
     <footer className="border-t border-stone-300 bg-stone-50">
-      <div className="mx-auto max-w-screen-xl space-y-4 px-4 py-8 lg:py-12">
-        <Brand isLarge={true} />
+      <div className="mx-auto flex max-w-screen-xl flex-col items-start justify-between gap-4 px-4 py-8 lg:flex-row lg:py-12">
+        <div className="space-y-4">
+          <Brand isLarge={true} />
 
-        <p className="max-w-lg text-pretty text-stone-700">
-          Free open source Tailwind CSS components for marketing and eCommerce websites, as well as
-          application interfaces.
-        </p>
+          <p className="stripped:hidden max-w-lg text-pretty text-stone-700">
+            Free open source Tailwind CSS components for marketing and eCommerce websites, as well
+            as application interfaces.
+          </p>
 
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <ul className="flex gap-4">
             {footerLinks.map((footerLink) => (
               <li key={footerLink.href}>
@@ -50,6 +51,8 @@ export default function Footer() {
             </a>
           </p>
         </div>
+
+        <MarketingToggle />
       </div>
     </footer>
   )

--- a/src/components/global/Github.jsx
+++ b/src/components/global/Github.jsx
@@ -10,7 +10,7 @@ export default function Github() {
 
       <Icon />
 
-      <span className="hidden sm:block sm:font-medium">11k</span>
+      <span className="stripped:hidden hidden sm:block sm:font-medium">11k</span>
     </a>
   )
 }

--- a/src/components/global/HeaderCta.jsx
+++ b/src/components/global/HeaderCta.jsx
@@ -1,6 +1,6 @@
 export default function HeaderCta() {
   return (
-    <section className="-mt-px border-y border-stone-300 bg-stone-50">
+    <section className="stripped:hidden -mt-px border-y border-stone-300 bg-stone-50">
       <div className="mx-auto flex max-w-screen-xl justify-center px-4 py-2">
         <a
           href="https://github.com/markmead/hyperui"

--- a/src/components/global/HeaderSearch.jsx
+++ b/src/components/global/HeaderSearch.jsx
@@ -196,7 +196,9 @@ function ComponentResult({ collectionItem }) {
       className="block px-4 py-2 transition-colors hover:bg-stone-50 focus:ring-2 focus:ring-indigo-400 focus:outline-none focus:ring-inset md:flex md:items-center md:justify-between"
     >
       <div className="flex items-center gap-2">
-        <span aria-hidden="true">{collectionItem.emoji}</span>
+        <span aria-hidden="true" className="stripped:hidden">
+          {collectionItem.emoji}
+        </span>
 
         <span className="font-medium text-stone-900">{collectionItem.title}</span>
       </div>
@@ -215,7 +217,9 @@ function BlogResult({ blogItem }) {
       className="block px-4 py-2 transition-colors hover:bg-stone-50 focus:ring-2 focus:ring-indigo-400 focus:outline-none focus:ring-inset"
     >
       <div className="flex items-center gap-2">
-        <span aria-hidden="true">{blogItem.emoji}</span>
+        <span aria-hidden="true" className="stripped:hidden">
+          {blogItem.emoji}
+        </span>
 
         <span className="line-clamp-1 font-medium text-pretty text-stone-900">
           {blogItem.title}

--- a/src/components/global/Hero.jsx
+++ b/src/components/global/Hero.jsx
@@ -4,17 +4,21 @@ export default function Hero({ children, subtitle, title }) {
   return (
     <section className="bg-white text-center">
       <div className="mx-auto max-w-screen-xl px-4 py-8 lg:py-12">
-        <div className="flex flex-col gap-4">
+        <div className="stripped:hidden flex flex-col gap-4">
           <h1 className="text-lg text-stone-700">{subtitle}</h1>
 
           <h2 className="order-first text-5xl font-bold text-stone-900 sm:text-6xl">{title}</h2>
         </div>
 
-        <div className="mx-auto mt-6 max-w-xl space-y-6">
+        <div className="stripped:hidden mx-auto mt-6 max-w-xl space-y-6">
           <p className="leading-relaxed text-pretty text-stone-700">{children}</p>
 
           <HeroUsps />
         </div>
+
+        <h1 className="stripped:block hidden text-5xl font-bold text-stone-900 sm:text-6xl">
+          {title}
+        </h1>
       </div>
     </section>
   )

--- a/src/components/global/MarketingToggle.jsx
+++ b/src/components/global/MarketingToggle.jsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+import Tooltip from '@component/global/Tooltip'
+
+export default function MarketingToggle() {
+  const [hideMarketing, setHideMarketing] = useState(null)
+  const [isLoaded, setIsLoaded] = useState(false)
+
+  useEffect(() => {
+    const localValue = localStorage.getItem('marketing:hide')
+
+    setHideMarketing(localValue === null ? false : localValue === 'true')
+    setIsLoaded(true)
+  }, [])
+
+  useEffect(() => {
+    if (!isLoaded) {
+      return
+    }
+
+    document.documentElement.setAttribute('data-stripped', hideMarketing)
+  }, [hideMarketing])
+
+  function handleChange() {
+    setHideMarketing(!hideMarketing)
+
+    localStorage.setItem('marketing:hide', `${!hideMarketing}`)
+  }
+
+  if (!isLoaded) {
+    return <></>
+  }
+
+  return (
+    <Tooltip tooltipContent="Use a stripped design and hide marketing content" tooltipSide="left">
+      <label className="inline-flex items-center gap-2 rounded-lg border border-stone-300 bg-white p-4 text-stone-700 shadow-sm">
+        <input
+          type="checkbox"
+          checked={hideMarketing}
+          onChange={handleChange}
+          className="size-5 rounded border-gray-300 text-indigo-500 shadow-sm"
+        />
+
+        <span className="font-medium">Stripped design</span>
+      </label>
+    </Tooltip>
+  )
+}

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -4,6 +4,8 @@
 @plugin '@tailwindcss/forms';
 @plugin '@tailwindcss/typography';
 
+@custom-variant stripped '[data-stripped="true"] &';
+
 @theme {
   --font-sans:
     var(--font-inter), ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2210,10 +2210,10 @@ eslint-plugin-react@^7.37.0, eslint-plugin-react@^7.37.5:
     string.prototype.matchall "^4.0.12"
     string.prototype.repeat "^1.0.0"
 
-eslint-plugin-unicorn@^61.0.1:
-  version "61.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-61.0.1.tgz#438d66e2451a00df8eacc1a6e2e3c853482a2a29"
-  integrity sha512-RwXXqS8oTxW7dVs6e4ZBpZkn1wB4qqNZSbCJektP8/Nzp/woJdfN/t7LVNcpGMZ57xWBs33K0ymZ7MV+VeQnbA==
+eslint-plugin-unicorn@^61.0.2:
+  version "61.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-61.0.2.tgz#fe410b1203666cef4d6a5b13b05caef814a6a2e4"
+  integrity sha512-zLihukvneYT7f74GNbVJXfWIiNQmkc/a9vYBTE4qPkQZswolWNdu+Wsp9sIXno1JOzdn6OUwLPd19ekXVkahRA==
   dependencies:
     "@babel/helper-validator-identifier" "^7.27.1"
     "@eslint-community/eslint-utils" "^4.7.0"


### PR DESCRIPTION
Idea stolen from Sentry 🤷‍♀️ 

This pull request introduces a new "Stripped design" mode that allows users to toggle the visibility of marketing content and certain UI elements for a cleaner interface. The implementation includes a new `MarketingToggle` component, updates to various components and styles to support the stripped mode, and a dependency update.

Key changes:

**Stripped design mode implementation:**

* Added a new `MarketingToggle` component that lets users enable or disable the stripped design mode, storing the preference in localStorage and setting a `data-stripped` attribute on the `<html>` element. (`src/components/global/MarketingToggle.jsx`)
* Registered a custom Tailwind CSS variant `stripped` to conditionally apply styles when stripped mode is active. (`src/styles/site.css`)

**Component updates for stripped mode:**

* Updated multiple components (such as `BlogCard`, `CollectionCard`, `PreviewBreakpoint`, `PreviewCopy`, `PreviewRtl`, `PreviewView`, `HeaderSearch`, `Hero`, `Github`, and others) to use the `stripped:hidden` and `stripped:mt-0` utility classes, hiding emojis, marketing sections, or adjusting spacing when stripped mode is enabled. [[1]](diffhunk://#diff-4f2f4e2d8ed0983850f9b0f5f29b567aeca5c7e0cc95980bbe998489f8940456L9-R13) [[2]](diffhunk://#diff-485c19a995410dc8fd0477ea815888753763c176c8c3a54e07c8518ebf210a6aL16-R20) [[3]](diffhunk://#diff-f2479e25292e166a128b84f8b42f36c34fc877f2f2671474c0bb87d437be632eL21-R24) [[4]](diffhunk://#diff-c0994762d1bed579d5ebd7548e13a483fde2934186ed74f5c102ce10eaf8044dL64-R67) [[5]](diffhunk://#diff-84bdb3270213d87807eb7ec4528612b83a720003b61f00f9100eac31d06e1b96L14-R17) [[6]](diffhunk://#diff-1d1cec5fa0f5b71e4d469eee6a15e6e6c9b26aafeace26dad358fbf8636ec6b2L14-R17) [[7]](diffhunk://#diff-340135e6b1e521bb101815fd491f1675a9a1793c4b8a10c204ac59e69c4b75caL199-R201) [[8]](diffhunk://#diff-340135e6b1e521bb101815fd491f1675a9a1793c4b8a10c204ac59e69c4b75caL218-R222) [[9]](diffhunk://#diff-6a0ca3cb59a826cd65b3213512aca1746cf67c61e48f80e457485fd2a29d7c64L7-R21) [[10]](diffhunk://#diff-d7f45ebad3acfcff949fccf3b5dd55973b8d7d301b972eb21c2d1bb96c17dbc2L13-R13) [[11]](diffhunk://#diff-cd3853b4da2888c300a4688ba927d9cca8399e8998d4f8b1a520b4028cbc7167L3-R3) [app/[components]/[category]/[collection]/page.jsxL90-R90](diffhunk://#diff-9f56fa1dac28eba287be43b1c0bea1b5386bd2ce25062fa937b71b502f67cbcbL90-R90))

**Footer and layout adjustments:**

* Modified the `Footer` component to include the new `MarketingToggle` and reorganized its layout to better accommodate the stripped mode. (`src/components/global/Footer.jsx`) [[1]](diffhunk://#diff-c6a43351abb9a8d6689d0b4cd333d78911ebe78b9fdf9cffdc85a95162f573beR4) [[2]](diffhunk://#diff-c6a43351abb9a8d6689d0b4cd333d78911ebe78b9fdf9cffdc85a95162f573beL19-L27) [[3]](diffhunk://#diff-c6a43351abb9a8d6689d0b4cd333d78911ebe78b9fdf9cffdc85a95162f573beR54-R55)

**Dependency update:**

* Updated the `eslint-plugin-unicorn` dependency to version `61.0.2` in `package.json`.