### PR TITLE
Feature - Add dark mode support for "Standout" component

### DIFF
--- a/public/components/application/alerts/3-dark.html
+++ b/public/components/application/alerts/3-dark.html
@@ -1,4 +1,4 @@
-<div role="alert" class="border-s-4 border-red-700 bg-red-50 p-4 dark:border-red-50 dark:bg-red-800">
+<div role="alert" class="border-s-4 border-red-700 bg-red-50 p-4 dark:border-red-500 dark:bg-red-800">
   <div class="flex items-center gap-2 text-red-700 dark:text-red-50">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-5">
       <path

--- a/public/components/application/alerts/3-dark.html
+++ b/public/components/application/alerts/3-dark.html
@@ -1,0 +1,18 @@
+<div role="alert" class="border-s-4 border-red-700 bg-red-50 p-4 dark:border-red-50 dark:bg-red-800">
+  <div class="flex items-center gap-2 text-red-700 dark:text-red-50">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-5">
+      <path
+        fill-rule="evenodd"
+        d="M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003zM12 8.25a.75.75 0 01.75.75v3.75a.75.75 0 01-1.5 0V9a.75.75 0 01.75-.75zm0 8.25a.75.75 0 100-1.5.75.75 0 000 1.5z"
+        clip-rule="evenodd"
+      />
+    </svg>
+
+    <strong class="font-medium"> Something went wrong </strong>
+  </div>
+
+  <p class="mt-2 text-sm text-red-700 dark:text-red-50">
+    Lorem ipsum dolor sit amet consectetur, adipisicing elit. Nemo quasi assumenda numquam deserunt
+    consectetur autem nihil quos debitis dolor culpa.
+  </p>
+</div>

--- a/src/data/components/application/alerts.mdx
+++ b/src/data/components/application/alerts.mdx
@@ -13,7 +13,7 @@ terms:
 components:
   - { title: 'Base', dark: true }
   - { title: 'Base with actions', dark: true }
-  - { title: 'Standout' }
+  - { title: 'Standout', dark: true }
 ---
 
 # Alert Components


### PR DESCRIPTION
This pull request introduces a new dark mode version of the "Standout" alert component and updates its metadata to indicate dark mode support. The most important changes are:

**Component Additions and Updates:**

* Added a new dark mode "Standout" alert component in `3-dark.html`, featuring appropriate styling and iconography for dark backgrounds.
* Updated the `alerts.mdx` metadata to indicate that the "Standout" alert now supports dark mode by setting `dark: true`.