### PR TITLE
Update - Add dark mode support alert component

### DIFF
--- a/public/components/application/alerts/3.html
+++ b/public/components/application/alerts/3.html
@@ -1,5 +1,5 @@
-<div role="alert" class="border-s-4 border-red-700 bg-red-50 p-4">
-  <div class="flex items-center gap-2 text-red-700">
+<div role="alert" class="border-s-4 border-red-700 bg-red-50 p-4 dark:border-red-400 dark:bg-gray-900">
+  <div class="flex items-center gap-2 text-red-700 dark:text-red-400">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-5">
       <path
         fill-rule="evenodd"
@@ -11,7 +11,7 @@
     <strong class="font-medium"> Something went wrong </strong>
   </div>
 
-  <p class="mt-2 text-sm text-red-700">
+  <p class="mt-2 text-sm text-red-700 dark:text-red-300">
     Lorem ipsum dolor sit amet consectetur, adipisicing elit. Nemo quasi assumenda numquam deserunt
     consectetur autem nihil quos debitis dolor culpa.
   </p>


### PR DESCRIPTION
Add Dark Mode Support to Alert Standout Component
Description
This PR adds dark mode support to the “alert-standout” component ([3.html](https://psychic-space-funicular-9pqj5ppjpx6cqq9.github.dev/)) using Tailwind CSS’s dark: variants. The update ensures proper color contrast for background, border, and text when the site is viewed in dark mode.

Background: Uses dark:bg-gray-900 for a deep, accessible background.
Border: Uses dark:border-red-400 for clear separation.
Text: Uses dark:text-red-400 and dark:text-red-300 for strong readability.
Motivation
Currently, the alert-standout component does not adapt to dark mode, which can result in poor visibility and accessibility for users who prefer or require dark themes. This update improves the user experience and visual consistency across light and dark modes.

Additional Context
This is my first Hacktoberfest contribution! 🎉
I’m happy to help add dark mode support to more components after this PR.
Please add the Hacktoberfest-accepted, hacktoberfest label to this PR.