### PR TITLE
Fix - Remove incorrect spacing between elements

### DIFF
--- a/public/components/marketing/footers/10-dark.html
+++ b/public/components/marketing/footers/10-dark.html
@@ -280,7 +280,7 @@
           <ul class="mt-8 space-y-4 text-sm">
             <li>
               <a
-                class="flex items-center justify-center gap-1.5 ltr:sm:justify-start rtl:sm:justify-end"
+                class="flex items-center justify-center gap-2 ltr:sm:justify-start rtl:sm:justify-end"
                 href="#"
               >
                 <svg
@@ -298,13 +298,13 @@
                   />
                 </svg>
 
-                <span class="flex-1 text-gray-700 dark:text-gray-300"> john@doe.com </span>
+                <span class="text-gray-700 dark:text-gray-300"> john@doe.com </span>
               </a>
             </li>
 
             <li>
               <a
-                class="flex items-center justify-center gap-1.5 ltr:sm:justify-start rtl:sm:justify-end"
+                class="flex items-center justify-center gap-2 ltr:sm:justify-start rtl:sm:justify-end"
                 href="#"
               >
                 <svg
@@ -322,12 +322,12 @@
                   />
                 </svg>
 
-                <span class="flex-1 text-gray-700 dark:text-gray-300">0123456789</span>
+                <span class="text-gray-700 dark:text-gray-300">0123456789</span>
               </a>
             </li>
 
             <li
-              class="flex items-start justify-center gap-1.5 ltr:sm:justify-start rtl:sm:justify-end"
+              class="flex items-start justify-center gap-2 ltr:sm:justify-start rtl:sm:justify-end"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -349,7 +349,7 @@
                 />
               </svg>
 
-              <address class="-mt-0.5 flex-1 text-gray-700 not-italic dark:text-gray-300">
+              <address class="text-gray-700 not-italic dark:text-gray-300">
                 213 Lane, London, United Kingdom
               </address>
             </li>

--- a/public/components/marketing/footers/10.html
+++ b/public/components/marketing/footers/10.html
@@ -234,7 +234,7 @@
           <ul class="mt-8 space-y-4 text-sm">
             <li>
               <a
-                class="flex items-center justify-center gap-1.5 ltr:sm:justify-start rtl:sm:justify-end"
+                class="flex items-center justify-center gap-2 ltr:sm:justify-start rtl:sm:justify-end"
                 href="#"
               >
                 <svg
@@ -252,13 +252,13 @@
                   />
                 </svg>
 
-                <span class="flex-1 text-gray-700">john@doe.com</span>
+                <span class="text-gray-700">john@doe.com</span>
               </a>
             </li>
 
             <li>
               <a
-                class="flex items-center justify-center gap-1.5 ltr:sm:justify-start rtl:sm:justify-end"
+                class="flex items-center justify-center gap-2 ltr:sm:justify-start rtl:sm:justify-end"
                 href="#"
               >
                 <svg
@@ -276,12 +276,12 @@
                   />
                 </svg>
 
-                <span class="flex-1 text-gray-700">0123456789</span>
+                <span class="text-gray-700">0123456789</span>
               </a>
             </li>
 
             <li
-              class="flex items-start justify-center gap-1.5 ltr:sm:justify-start rtl:sm:justify-end"
+              class="flex items-start justify-center gap-2 ltr:sm:justify-start rtl:sm:justify-end"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -303,7 +303,7 @@
                 />
               </svg>
 
-              <address class="-mt-0.5 flex-1 text-gray-700 not-italic">
+              <address class="text-gray-700 not-italic">
                 213 Lane, London, United Kingdom
               </address>
             </li>


### PR DESCRIPTION
### Removed unwanted/incorrect spacing between SVG icon and link text

**Approch:** Removed _"flex-1"_ class from link text

**After Fix Screenshots**

<img width="1890" height="1088" alt="Screenshot 2025-10-25 141237" src="https://github.com/user-attachments/assets/699224cf-4906-42f2-b0aa-1d7a7f717a95" />

<img width="1898" height="1071" alt="Screenshot 2025-10-25 141325" src="https://github.com/user-attachments/assets/24e59db2-a66b-4581-a1e9-6a7c06beb0a3" />

