### PR TITLE
Hotfix - Incorrect spacing on footer component

### DIFF
--- a/public/components/marketing/footers/10-dark.html
+++ b/public/components/marketing/footers/10-dark.html
@@ -280,7 +280,7 @@
           <ul class="mt-8 space-y-4 text-sm">
             <li>
               <a
-                class="flex items-center justify-center gap-1.5 ltr:sm:justify-start rtl:sm:justify-end"
+                class="flex items-center justify-center gap-2 ltr:sm:justify-start rtl:sm:justify-end"
                 href="#"
               >
                 <svg
@@ -298,13 +298,13 @@
                   />
                 </svg>
 
-                <span class="flex-1 text-gray-700 dark:text-gray-300"> john@doe.com </span>
+                <span class="text-gray-700 dark:text-gray-300"> john@doe.com </span>
               </a>
             </li>
 
             <li>
               <a
-                class="flex items-center justify-center gap-1.5 ltr:sm:justify-start rtl:sm:justify-end"
+                class="flex items-center justify-center gap-2 ltr:sm:justify-start rtl:sm:justify-end"
                 href="#"
               >
                 <svg
@@ -322,12 +322,12 @@
                   />
                 </svg>
 
-                <span class="flex-1 text-gray-700 dark:text-gray-300">0123456789</span>
+                <span class="text-gray-700 dark:text-gray-300">0123456789</span>
               </a>
             </li>
 
             <li
-              class="flex items-start justify-center gap-1.5 ltr:sm:justify-start rtl:sm:justify-end"
+              class="flex items-start justify-center gap-2 ltr:sm:justify-start rtl:sm:justify-end"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -349,7 +349,7 @@
                 />
               </svg>
 
-              <address class="-mt-0.5 flex-1 text-gray-700 not-italic dark:text-gray-300">
+              <address class="text-gray-700 not-italic dark:text-gray-300">
                 213 Lane, London, United Kingdom
               </address>
             </li>

--- a/public/components/marketing/footers/10.html
+++ b/public/components/marketing/footers/10.html
@@ -234,7 +234,7 @@
           <ul class="mt-8 space-y-4 text-sm">
             <li>
               <a
-                class="flex items-center justify-center gap-1.5 ltr:sm:justify-start rtl:sm:justify-end"
+                class="flex items-center justify-center gap-2 ltr:sm:justify-start rtl:sm:justify-end"
                 href="#"
               >
                 <svg
@@ -252,13 +252,13 @@
                   />
                 </svg>
 
-                <span class="flex-1 text-gray-700">john@doe.com</span>
+                <span class="text-gray-700">john@doe.com</span>
               </a>
             </li>
 
             <li>
               <a
-                class="flex items-center justify-center gap-1.5 ltr:sm:justify-start rtl:sm:justify-end"
+                class="flex items-center justify-center gap-2 ltr:sm:justify-start rtl:sm:justify-end"
                 href="#"
               >
                 <svg
@@ -276,12 +276,12 @@
                   />
                 </svg>
 
-                <span class="flex-1 text-gray-700">0123456789</span>
+                <span class="text-gray-700">0123456789</span>
               </a>
             </li>
 
             <li
-              class="flex items-start justify-center gap-1.5 ltr:sm:justify-start rtl:sm:justify-end"
+              class="flex items-start justify-center gap-2 ltr:sm:justify-start rtl:sm:justify-end"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -303,7 +303,7 @@
                 />
               </svg>
 
-              <address class="-mt-0.5 flex-1 text-gray-700 not-italic">
+              <address class="text-gray-700 not-italic">
                 213 Lane, London, United Kingdom
               </address>
             </li>


### PR DESCRIPTION
**Fixes #640**

### 📝 Summary of Changes

This Pull Request addresses the visual bug where the 10th item in the site footer exhibited an incorrect gap between the SVG icon and its corresponding text link when viewed on narrow screens (mobile breakpoints).

The issue was caused by the link text element utilizing the `flex-1` utility class, forcing it to consume all available horizontal space, pushing the text away from the icon.

### ✅ Solution

1.  Removed the redundant `flex-1` class from the link text element for the 10th footer item.
2.  Ensured the link text now correctly wraps its content, allowing the icon and text to sit adjacent to each other with minimal, consistent spacing.

### 🧪 Testing & Verification

The fix was verified locally by:

* Checking the component on Chrome Developer Tools at common mobile breakpoints (320px, 480px, 768px).
* Confirmed that the spacing issue is resolved and the icon and text are correctly aligned.
* Confirmed that no other footer items or components were affected by this change.

---
#### 📸 Screenshots

**Before (Bug)**

<img width="360" height="660" alt="Screenshot 2025-10-25 120111" src="https://github.com/user-attachments/assets/9ee47127-3071-497a-a6ba-4a7f6f72b430" />


**After (Fix)**

<img width="1898" height="1071" alt="Screenshot 2025-10-25 141325" src="https://github.com/user-attachments/assets/d8782a01-7551-4fb6-94e7-521d46851082" />



