### PR TITLE
Hotfix - Use cached HTML content for copy button

### DIFF
--- a/src/components/ComponentPreview.astro
+++ b/src/components/ComponentPreview.astro
@@ -58,6 +58,8 @@ const { src, title, dark = false, index = 1, wrapper = '' } = Astro.props
         return
       }
 
+      this.setupHtml()
+
       this.setupEventListeners()
     }
 
@@ -90,15 +92,6 @@ const { src, title, dark = false, index = 1, wrapper = '' } = Astro.props
 
         const previewEls = this.querySelectorAll('[data-preview]')
 
-        if (!isPreviewing && !this.contentHtml) {
-          if (this.iframeEl?.contentDocument) {
-            const docClone = this.iframeEl.contentDocument.cloneNode(true) as Document
-
-            this.contentHtml = this.sanitizeContent((docClone as Document).body.innerHTML)
-            this.previewEl!.innerText = this.contentHtml
-          }
-        }
-
         previewEls.forEach((previewEl) => {
           previewEl.setAttribute('data-preview', isPreviewing ? 'true' : 'false')
         })
@@ -110,15 +103,11 @@ const { src, title, dark = false, index = 1, wrapper = '' } = Astro.props
         if (this.iframeEl?.contentDocument) {
           this.iframeEl.contentDocument.documentElement.setAttribute('dir', isLtr ? 'ltr' : 'rtl')
         }
-
-        if (this.iframeEl?.contentDocument) {
-          this.iframeEl.contentDocument.documentElement.setAttribute('dir', isLtr ? 'ltr' : 'rtl')
-        }
       }
 
       this.copyHandler = () => {
-        if (this.previewEl?.textContent) {
-          navigator.clipboard.writeText(this.previewEl.textContent)
+        if (this.contentHtml) {
+          navigator.clipboard.writeText(this.contentHtml)
         }
       }
 
@@ -127,6 +116,15 @@ const { src, title, dark = false, index = 1, wrapper = '' } = Astro.props
         document.addEventListener(`preview:view:${this.contentSrc}`, this.viewHandler)
         document.addEventListener(`preview:direction:${this.contentSrc}`, this.directionHandler)
         document.addEventListener(`preview:copy:${this.contentSrc}`, this.copyHandler)
+      }
+    }
+
+    private setupHtml() {
+      if (this.iframeEl?.contentDocument) {
+        const docClone = this.iframeEl.contentDocument.cloneNode(true) as Document
+
+        this.contentHtml = this.sanitizeContent((docClone as Document).body.innerHTML)
+        this.previewEl!.innerText = this.contentHtml
       }
     }
 

--- a/src/components/ComponentPreview.astro
+++ b/src/components/ComponentPreview.astro
@@ -58,8 +58,6 @@ const { src, title, dark = false, index = 1, wrapper = '' } = Astro.props
         return
       }
 
-      this.setupHtml()
-
       this.setupEventListeners()
     }
 
@@ -92,6 +90,12 @@ const { src, title, dark = false, index = 1, wrapper = '' } = Astro.props
 
         const previewEls = this.querySelectorAll('[data-preview]')
 
+        const contentHtml = this.getContent()
+
+        if (contentHtml && this.previewEl) {
+          this.previewEl.textContent = contentHtml
+        }
+
         previewEls.forEach((previewEl) => {
           previewEl.setAttribute('data-preview', isPreviewing ? 'true' : 'false')
         })
@@ -106,8 +110,14 @@ const { src, title, dark = false, index = 1, wrapper = '' } = Astro.props
       }
 
       this.copyHandler = () => {
-        if (this.contentHtml) {
-          navigator.clipboard.writeText(this.contentHtml)
+        const contentHtml = this.getContent()
+
+        try {
+          if (contentHtml) {
+            navigator.clipboard.writeText(contentHtml)
+          }
+        } catch {
+          // We do nothing
         }
       }
 
@@ -119,29 +129,20 @@ const { src, title, dark = false, index = 1, wrapper = '' } = Astro.props
       }
     }
 
-    private setupHtml() {
-      if (!this.iframeEl) {
-        return
+    private getContent(): string | null {
+      if (this.contentHtml) {
+        return this.contentHtml
       }
 
-      if (this.iframeEl.contentDocument?.readyState === 'complete') {
-        this.extractContent()
-
-        return
-      }
-
-      this.iframeEl.addEventListener('load', () => this.extractContent(), { once: true })
-    }
-
-    private extractContent() {
       if (this.iframeEl?.contentDocument) {
         const docClone = this.iframeEl.contentDocument.cloneNode(true) as Document
 
         this.contentHtml = this.sanitizeContent((docClone as Document).body.innerHTML)
-        if (this.previewEl) {
-          this.previewEl.innerText = this.contentHtml
-        }
+
+        return this.contentHtml
       }
+
+      return null
     }
 
     private sanitizeContent(contentHtml: string): string {

--- a/src/components/ComponentPreview.astro
+++ b/src/components/ComponentPreview.astro
@@ -120,6 +120,20 @@ const { src, title, dark = false, index = 1, wrapper = '' } = Astro.props
     }
 
     private setupHtml() {
+      if (!this.iframeEl) {
+        return
+      }
+
+      if (this.iframeEl.contentDocument?.readyState === 'complete') {
+        this.extractContent()
+
+        return
+      }
+
+      this.iframeEl.addEventListener('load', () => this.extractContent(), { once: true })
+    }
+
+    private extractContent() {
       if (this.iframeEl?.contentDocument) {
         const docClone = this.iframeEl.contentDocument.cloneNode(true) as Document
 

--- a/src/components/ComponentPreview.astro
+++ b/src/components/ComponentPreview.astro
@@ -124,7 +124,9 @@ const { src, title, dark = false, index = 1, wrapper = '' } = Astro.props
         const docClone = this.iframeEl.contentDocument.cloneNode(true) as Document
 
         this.contentHtml = this.sanitizeContent((docClone as Document).body.innerHTML)
-        this.previewEl!.innerText = this.contentHtml
+        if (this.previewEl) {
+          this.previewEl.innerText = this.contentHtml
+        }
       }
     }
 


### PR DESCRIPTION
Closes #652 

This pull request refactors how preview content is retrieved and copied in the `ComponentPreview.astro` component. The main improvement is the introduction of a dedicated `getContent()` method, which centralizes content extraction logic, resulting in cleaner and more maintainable code. Additionally, copy-to-clipboard functionality now uses this method and includes error handling for robustness.

**Content retrieval and preview display:**
* Added a private `getContent()` method to encapsulate logic for extracting and sanitizing preview HTML content, replacing duplicated code and improving maintainability.
* Updated preview rendering logic to use the new `getContent()` method, ensuring consistent and reliable content extraction for display.

**Copy-to-clipboard improvements:**
* Refactored the copy handler to use `getContent()`, and added error handling to gracefully handle clipboard write failures.