### PR TITLE
Bugfix - Preserve element trailing slash when copying HTML

### DIFF
--- a/src/components/ComponentPreview.astro
+++ b/src/components/ComponentPreview.astro
@@ -163,11 +163,20 @@ const { src, title, dark = false, index = 1, wrapper = '' } = Astro.props
     }
 
     private sanitizeContent(contentHtml: string): string {
-      return contentHtml
+      let sanitized = contentHtml
         .split('\n')
         .map((htmlLine) => htmlLine.replace(/^\s{4}/, ''))
         .join('\n')
         .trim()
+
+      // Fix: Restore trailing slash for input elements    
+      const regexWithAttrs = new RegExp(`<input(\\s[^>]*[^/])>`, 'gi')
+      sanitized = sanitized.replace(regexWithAttrs, `<input$1 />`)
+
+      const regexNoAttrs = new RegExp(`<input>`, 'gi')
+      sanitized = sanitized.replace(regexNoAttrs, `<input />`)
+
+      return sanitized
     }
   }
 


### PR DESCRIPTION
## Description
Fixes issue where `<input>` elements lose their trailing slash (`/>`) when copied from the HTML view.

## Problem
When using the "Copy HTML" feature, the `innerHTML` serialization in the browser removes trailing slashes from self-closing tags like `<input />`, resulting in `<input>` instead. This creates inconsistency with the source files in the repository.

## Solution
Added post-processing in the `sanitizeContent()` method to restore trailing slashes specifically for `<input>` elements after `innerHTML` serialization, maintaining consistency with the codebase.

## Changes
- Modified `src/components/ComponentPreview.astro`
- Updated `sanitizeContent()` method to handle:
  - `<input>` (no attributes) → `<input />`
  - `<input attributes>` (with attributes) → `<input attributes />`

## Testing
- Tested locally with `npm run dev`
- Verified input elements with attributes get trailing slash
- Verified input elements without attributes get trailing slash
- Confirmed existing input elements with trailing slash remain unchanged
- No breaking changes to other components

Closes #[675]