### PR TITLE
Feature - Enhance component schema with optional pattern links and UI updates

### DIFF
--- a/src/components/TooltipWrapper.astro
+++ b/src/components/TooltipWrapper.astro
@@ -1,0 +1,17 @@
+---
+interface Props {
+  text: string
+  class?: string
+}
+
+const { text, class: className } = Astro.props
+---
+
+<span class:list={['group/tooltip relative inline-flex items-center', className]}>
+  <slot />
+
+  <span class="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 -translate-x-1/2 rounded bg-gray-900 px-2 py-1 text-xs whitespace-nowrap text-white opacity-0 transition-opacity group-hover/tooltip:opacity-100 group-focus-within/tooltip:opacity-100">
+    {text}
+    <span class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900" />
+  </span>
+</span>

--- a/src/components/TooltipWrapper.astro
+++ b/src/components/TooltipWrapper.astro
@@ -10,8 +10,13 @@ const { text, class: className } = Astro.props
 <span class:list={['group/tooltip relative inline-flex items-center', className]}>
   <slot />
 
-  <span class="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 -translate-x-1/2 rounded bg-gray-900 px-2 py-1 text-xs whitespace-nowrap text-white opacity-0 transition-opacity group-hover/tooltip:opacity-100 group-focus-within/tooltip:opacity-100">
+  <span
+    aria-hidden="true"
+    class="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 -translate-x-1/2 rounded bg-gray-900 px-2 py-1 text-xs whitespace-nowrap text-white opacity-0 transition-opacity group-focus-within/tooltip:opacity-100 group-hover/tooltip:opacity-100"
+  >
     {text}
-    <span class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900" />
+    <span
+      class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900"
+    ></span>
   </span>
 </span>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -25,6 +25,12 @@ const collection = z.object({
   terms: z.array(z.string()),
   title: z.string(),
   wrapper: z.string().default('h-[600px]'),
+  pattern: z
+    .object({
+      url: z.string(),
+      description: z.string(),
+    })
+    .optional(),
   components: z.array(
     z.object({
       contributors: z.array(z.string()).default(['markmead']),

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -25,10 +25,11 @@ const collection = z.object({
   terms: z.array(z.string()),
   title: z.string(),
   wrapper: z.string().default('h-[600px]'),
-  pattern: z
+  pattern: z.string().optional(),
+  updated: z
     .object({
-      url: z.string(),
-      description: z.string(),
+      date: z.coerce.date(),
+      commit: z.string().optional(),
     })
     .optional(),
   components: z.array(

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -25,11 +25,11 @@ const collection = z.object({
   terms: z.array(z.string()),
   title: z.string(),
   wrapper: z.string().default('h-[600px]'),
-  pattern: z.string().optional(),
+  pattern: z.url().optional(),
   updated: z
     .object({
       date: z.coerce.date(),
-      commit: z.string().optional(),
+      commit: z.string(),
     })
     .optional(),
   components: z.array(

--- a/src/content/collection/application/dropdown.mdx
+++ b/src/content/collection/application/dropdown.mdx
@@ -3,6 +3,9 @@ title: Dropdowns
 description: Responsive dropdown menu components for navigation, filters, settings, and user actions in web applications.
 category: application
 slug: dropdown
+pattern:
+  url: https://js.hyperui.dev/patterns/dropdown/
+  description: Need interactivty? Take a look at `huxDropdown` from HyperUX
 terms:
   - menu
   - navigation

--- a/src/content/collection/application/dropdown.mdx
+++ b/src/content/collection/application/dropdown.mdx
@@ -3,9 +3,7 @@ title: Dropdowns
 description: Responsive dropdown menu components for navigation, filters, settings, and user actions in web applications.
 category: application
 slug: dropdown
-pattern:
-  url: https://js.hyperui.dev/patterns/dropdown/
-  description: Need interactivty? Take a look at `huxDropdown` from HyperUX
+pattern: https://js.hyperui.dev/patterns/dropdown/
 terms:
   - menu
   - navigation

--- a/src/content/collection/application/filters.mdx
+++ b/src/content/collection/application/filters.mdx
@@ -4,6 +4,9 @@ description: Responsive filter components for sorting, searching, and refining c
 category: application
 slug: filters
 wrapper: h-[400px]
+pattern:
+  url: https://js.hyperui.dev/patterns/dropdown/
+  description: Need interactivty? Take a look at `huxDropdown` from HyperUX
 terms:
   - form
   - input

--- a/src/content/collection/application/filters.mdx
+++ b/src/content/collection/application/filters.mdx
@@ -4,9 +4,7 @@ description: Responsive filter components for sorting, searching, and refining c
 category: application
 slug: filters
 wrapper: h-[400px]
-pattern:
-  url: https://js.hyperui.dev/patterns/dropdown/
-  description: Need interactivty? Take a look at `huxDropdown` from HyperUX
+pattern: https://js.hyperui.dev/patterns/dropdown/
 terms:
   - form
   - input

--- a/src/content/collection/application/modals.mdx
+++ b/src/content/collection/application/modals.mdx
@@ -3,9 +3,7 @@ title: Modals
 description: Modal and dialog components for web applications. Includes simple modals, close buttons, and action modals with responsive, customizable designs.
 category: application
 slug: modals
-pattern:
-  url: https://js.hyperui.dev/patterns/dialog/
-  description: Need interactivty? Take a look at `huxDialog` from HyperUX
+pattern: https://js.hyperui.dev/patterns/dialog/
 terms:
   - dialog
   - popup

--- a/src/content/collection/application/modals.mdx
+++ b/src/content/collection/application/modals.mdx
@@ -3,6 +3,9 @@ title: Modals
 description: Modal and dialog components for web applications. Includes simple modals, close buttons, and action modals with responsive, customizable designs.
 category: application
 slug: modals
+pattern:
+  url: https://js.hyperui.dev/patterns/dialog/
+  description: Need interactivty? Take a look at `huxDialog` from HyperUX
 terms:
   - dialog
   - popup

--- a/src/content/collection/application/selects.mdx
+++ b/src/content/collection/application/selects.mdx
@@ -4,9 +4,7 @@ description: Customizable select components and responsive dropdown menus for fi
 category: application
 slug: selects
 wrapper: h-[400px]
-pattern:
-  url: https://js.hyperui.dev/patterns/dropdown/
-  description: Need interactivty? Take a look at `huxDropdown` from HyperUX
+pattern: https://js.hyperui.dev/patterns/dropdown/
 terms:
   - dropdown
   - filter

--- a/src/content/collection/application/selects.mdx
+++ b/src/content/collection/application/selects.mdx
@@ -4,6 +4,9 @@ description: Customizable select components and responsive dropdown menus for fi
 category: application
 slug: selects
 wrapper: h-[400px]
+pattern:
+  url: https://js.hyperui.dev/patterns/dropdown/
+  description: Need interactivty? Take a look at `huxDropdown` from HyperUX
 terms:
   - dropdown
   - filter

--- a/src/content/collection/application/side-menu.mdx
+++ b/src/content/collection/application/side-menu.mdx
@@ -3,9 +3,7 @@ title: Side Menu
 description: Responsive side menu and navigation components for dashboards, admin panels, and web applications.
 category: application
 slug: side-menu
-pattern:
-  url: https://js.hyperui.dev/patterns/dialog/
-  description: Need interactivty? Take a look at `huxDialog` from HyperUX
+pattern: https://js.hyperui.dev/patterns/dialog/
 terms:
   - navigation
 components:

--- a/src/content/collection/application/side-menu.mdx
+++ b/src/content/collection/application/side-menu.mdx
@@ -3,6 +3,9 @@ title: Side Menu
 description: Responsive side menu and navigation components for dashboards, admin panels, and web applications.
 category: application
 slug: side-menu
+pattern:
+  url: https://js.hyperui.dev/patterns/dialog/
+  description: Need interactivty? Take a look at `huxDialog` from HyperUX
 terms:
   - navigation
 components:

--- a/src/content/collection/application/steps.mdx
+++ b/src/content/collection/application/steps.mdx
@@ -4,9 +4,7 @@ description: Step indicator components for onboarding, progress tracking, and mu
 category: application
 slug: steps
 wrapper: h-[200px]
-# pattern:
-#   url: https://js.hyperui.dev/patterns/stepper/
-#   description: Need interactivty? Take a look at `huxStepper` from HyperUX
+# pattern: https://js.hyperui.dev/patterns/stepper/
 terms:
   - breadcrumb
   - progress

--- a/src/content/collection/application/steps.mdx
+++ b/src/content/collection/application/steps.mdx
@@ -4,6 +4,9 @@ description: Step indicator components for onboarding, progress tracking, and mu
 category: application
 slug: steps
 wrapper: h-[200px]
+# pattern:
+#   url: https://js.hyperui.dev/patterns/stepper/
+#   description: Need interactivty? Take a look at `huxStepper` from HyperUX
 terms:
   - breadcrumb
   - progress

--- a/src/content/collection/application/tabs.mdx
+++ b/src/content/collection/application/tabs.mdx
@@ -4,6 +4,9 @@ description: Responsive tab components for organizing content sections with cust
 category: application
 slug: tabs
 wrapper: h-[400px]
+pattern:
+  url: https://js.hyperui.dev/patterns/tabs/
+  description: Need interactivty? Take a look at `huxTabs` from HyperUX
 terms:
   - navigation
 components:

--- a/src/content/collection/application/tabs.mdx
+++ b/src/content/collection/application/tabs.mdx
@@ -4,9 +4,7 @@ description: Responsive tab components for organizing content sections with cust
 category: application
 slug: tabs
 wrapper: h-[400px]
-pattern:
-  url: https://js.hyperui.dev/patterns/tabs/
-  description: Need interactivty? Take a look at `huxTabs` from HyperUX
+pattern: https://js.hyperui.dev/patterns/tabs/
 terms:
   - navigation
 components:

--- a/src/content/collection/neobrutalism/selects.mdx
+++ b/src/content/collection/neobrutalism/selects.mdx
@@ -4,9 +4,7 @@ description: Neobrutalism-style select components built with Tailwind CSS. Featu
 category: neobrutalism
 slug: selects
 wrapper: h-[400px]
-pattern:
-  url: https://js.hyperui.dev/patterns/dropdown/
-  description: Need interactivty? Take a look at `huxDropdown` from HyperUX
+pattern: https://js.hyperui.dev/patterns/dropdown/
 terms:
   - dropdown
   - filter

--- a/src/content/collection/neobrutalism/selects.mdx
+++ b/src/content/collection/neobrutalism/selects.mdx
@@ -4,6 +4,9 @@ description: Neobrutalism-style select components built with Tailwind CSS. Featu
 category: neobrutalism
 slug: selects
 wrapper: h-[400px]
+pattern:
+  url: https://js.hyperui.dev/patterns/dropdown/
+  description: Need interactivty? Take a look at `huxDropdown` from HyperUX
 terms:
   - dropdown
   - filter

--- a/src/content/collection/neobrutalism/tabs.mdx
+++ b/src/content/collection/neobrutalism/tabs.mdx
@@ -4,9 +4,7 @@ description: Brutalist tab components for Tailwind CSS. Bold, minimalist tabbed 
 category: neobrutalism
 slug: tabs
 wrapper: h-[400px]
-pattern:
-  url: https://js.hyperui.dev/patterns/tabs/
-  description: Need interactivty? Take a look at `huxTabs` from HyperUX
+pattern: https://js.hyperui.dev/patterns/tabs/
 terms:
   - navigation
 components:

--- a/src/content/collection/neobrutalism/tabs.mdx
+++ b/src/content/collection/neobrutalism/tabs.mdx
@@ -4,6 +4,9 @@ description: Brutalist tab components for Tailwind CSS. Bold, minimalist tabbed 
 category: neobrutalism
 slug: tabs
 wrapper: h-[400px]
+pattern:
+  url: https://js.hyperui.dev/patterns/tabs/
+  description: Need interactivty? Take a look at `huxTabs` from HyperUX
 terms:
   - navigation
 components:

--- a/src/layouts/ComponentPost.astro
+++ b/src/layouts/ComponentPost.astro
@@ -133,7 +133,7 @@ const componentPageSchema = {
         <span class="group relative">
           Updated:
           {
-            updated?.date ? (
+            updated?.commit ? (
               <a
                 href={`https://github.com/markmead/hyperui/commit/${updated.commit}`}
                 target="_blank"
@@ -149,8 +149,8 @@ const componentPageSchema = {
               </a>
             ) : (
               <>
-                N/A
-                <span class="sr-only">No commit information available</span>
+                Not available
+                <span class="sr-only">No commit information available.</span>
                 <span class="pointer-events-none absolute bottom-full left-1/2 mb-2 -translate-x-1/2 rounded bg-gray-900 px-2 py-1 text-xs whitespace-nowrap text-white opacity-0 transition-opacity group-hover:opacity-100">
                   No commit information available
                   <span class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900" />

--- a/src/layouts/ComponentPost.astro
+++ b/src/layouts/ComponentPost.astro
@@ -2,7 +2,7 @@
 import type { CollectionEntry } from 'astro:content'
 import type { ComponentPreview } from '../types/component'
 
-import { Moon } from '@lucide/astro'
+import { Moon, Dot } from '@lucide/astro'
 
 import BaseLayout from './BaseLayout.astro'
 import PreviewWrapper from '../components/PreviewWrapper.astro'
@@ -13,16 +13,8 @@ type Props =
   | CollectionEntry<'marketing'>['data']
   | CollectionEntry<'neobrutalism'>['data']
 
-const {
-  title,
-  category,
-  components,
-  description,
-  slug,
-  terms,
-  wrapper,
-  pattern = null,
-} = Astro.props
+const { title, category, components, description, slug, terms, wrapper, pattern, updated } =
+  Astro.props
 
 const darkCount = components.filter(({ dark }) => !!dark).length
 const totalCount = components.length
@@ -101,42 +93,71 @@ const componentPageSchema = {
     <slot />
 
     <div class="mx-auto max-w-7xl space-y-8 px-4">
-      <div class="max-w-lg rounded-lg border border-gray-200 bg-gray-50 p-4 text-gray-600">
-        <div class="inline-flex items-center gap-2">
-          <Moon class="size-5 shrink-0" />
+      <div class="flex flex-wrap items-center gap-2 text-sm text-gray-600">
+        <span>
+          {darkCount}/{totalCount} Dark Mode
 
-          <p class="font-medium">
-            {darkCount} of {totalCount} components have dark mode variants
-          </p>
-        </div>
+          {
+            darkCount !== totalCount && (
+              <a
+                href="https://github.com/markmead/hyperui/issues/new"
+                target="_blank"
+                rel="noreferrer"
+                class="text-gray-500 transition-colors hover:text-gray-700"
+              >
+                (Request)
+              </a>
+            )
+          }
+        </span>
 
-        <p class="text-sm text-pretty">
-          Need a dark mode component or found a bug?
-          <a
-            href="https://github.com/markmead/hyperui/issues/new"
-            target="_blank"
-            rel="noreferrer"
-            class="underline transition-colors hover:text-gray-900"
-          >
-            Create an issue on GitHub
-          </a>
-        </p>
+        <Dot class="size-6 text-gray-400" />
+
+        {
+          pattern && (
+            <>
+              <a
+                href={pattern}
+                target="_blank"
+                rel="noreferrer"
+                class="transition-colors hover:text-gray-900"
+              >
+                HyperUX Pattern Available
+              </a>
+
+              <Dot class="size-6 text-gray-400" />
+            </>
+          )
+        }
+
+        <span class="group relative">
+          Updated:
+          {
+            updated?.commit ? (
+              <a
+                href={`https://github.com/markmead/hyperui/commit/${updated?.commit}`}
+                target="_blank"
+                rel="noreferrer"
+                class="transition-colors hover:text-gray-900"
+              >
+                {updated.date.toLocaleDateString(undefined, {
+                  year: 'numeric',
+                  month: 'short',
+                  day: 'numeric',
+                })}
+              </a>
+            ) : (
+              <>
+                N/A
+                <span class="pointer-events-none absolute bottom-full left-1/2 mb-2 -translate-x-1/2 rounded bg-gray-900 px-2 py-1 text-xs whitespace-nowrap text-white opacity-0 transition-opacity group-hover:opacity-100">
+                  No commit information available
+                  <span class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900" />
+                </span>
+              </>
+            )
+          }
+        </span>
       </div>
-
-      {
-        pattern && (
-          <div class="max-w-lg rounded-lg border border-gray-200 bg-gray-50 p-4 text-gray-600">
-            <a
-              href={pattern.url}
-              target="_blank"
-              rel="noreferrer"
-              class="font-medium underline transition-colors hover:text-gray-900"
-            >
-              {pattern.description}
-            </a>
-          </div>
-        )
-      }
 
       {
         formattedComponents.map((component) => (

--- a/src/layouts/ComponentPost.astro
+++ b/src/layouts/ComponentPost.astro
@@ -13,7 +13,16 @@ type Props =
   | CollectionEntry<'marketing'>['data']
   | CollectionEntry<'neobrutalism'>['data']
 
-const { title, category, components, description, slug, terms, wrapper } = Astro.props
+const {
+  title,
+  category,
+  components,
+  description,
+  slug,
+  terms,
+  wrapper,
+  pattern = null,
+} = Astro.props
 
 const darkCount = components.filter(({ dark }) => !!dark).length
 const totalCount = components.length
@@ -113,6 +122,21 @@ const componentPageSchema = {
           </a>
         </p>
       </div>
+
+      {
+        pattern && (
+          <div class="max-w-lg rounded-lg border border-gray-200 bg-gray-50 p-4 text-gray-600">
+            <a
+              href={pattern.url}
+              target="_blank"
+              rel="noreferrer"
+              class="font-medium underline transition-colors hover:text-gray-900"
+            >
+              {pattern.description}
+            </a>
+          </div>
+        )
+      }
 
       {
         formattedComponents.map((component) => (

--- a/src/layouts/ComponentPost.astro
+++ b/src/layouts/ComponentPost.astro
@@ -2,7 +2,7 @@
 import type { CollectionEntry } from 'astro:content'
 import type { ComponentPreview } from '../types/component'
 
-import { Moon, Dot } from '@lucide/astro'
+import { Dot } from '@lucide/astro'
 
 import BaseLayout from './BaseLayout.astro'
 import PreviewWrapper from '../components/PreviewWrapper.astro'

--- a/src/layouts/ComponentPost.astro
+++ b/src/layouts/ComponentPost.astro
@@ -7,6 +7,7 @@ import { Dot } from '@lucide/astro'
 import BaseLayout from './BaseLayout.astro'
 import PreviewWrapper from '../components/PreviewWrapper.astro'
 import RelatedComponents from '../components/RelatedComponents.astro'
+import TooltipWrapper from '../components/TooltipWrapper.astro'
 
 type Props =
   | CollectionEntry<'application'>['data']
@@ -116,21 +117,23 @@ const componentPageSchema = {
         {
           pattern && (
             <>
-              <a
-                href={pattern}
-                target="_blank"
-                rel="noreferrer"
-                class="transition-colors hover:text-gray-900"
-              >
-                HyperUX Pattern Available
-              </a>
+              <TooltipWrapper text="View related HyperUX pattern documentation">
+                <a
+                  href={pattern}
+                  target="_blank"
+                  rel="noreferrer"
+                  class="transition-colors hover:text-gray-900"
+                >
+                  HyperUX Pattern Available
+                </a>
+              </TooltipWrapper>
 
               <Dot class="size-6 text-gray-400" />
             </>
           )
         }
 
-        <span class="group relative">
+        <span>
           Updated:
           {
             updated?.commit ? (
@@ -149,12 +152,10 @@ const componentPageSchema = {
               </a>
             ) : (
               <>
-                Not available
+                <TooltipWrapper text="No commit information available">
+                  N/A
+                </TooltipWrapper>
                 <span class="sr-only">No commit information available.</span>
-                <span class="pointer-events-none absolute bottom-full left-1/2 mb-2 -translate-x-1/2 rounded bg-gray-900 px-2 py-1 text-xs whitespace-nowrap text-white opacity-0 transition-opacity group-hover:opacity-100">
-                  No commit information available
-                  <span class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900" />
-                </span>
               </>
             )
           }

--- a/src/layouts/ComponentPost.astro
+++ b/src/layouts/ComponentPost.astro
@@ -133,22 +133,24 @@ const componentPageSchema = {
         <span class="group relative">
           Updated:
           {
-            updated?.commit ? (
+            updated?.date ? (
               <a
-                href={`https://github.com/markmead/hyperui/commit/${updated?.commit}`}
+                href={`https://github.com/markmead/hyperui/commit/${updated.commit}`}
                 target="_blank"
                 rel="noreferrer"
                 class="transition-colors hover:text-gray-900"
               >
-                {updated.date.toLocaleDateString(undefined, {
+                {updated.date.toLocaleDateString('en-US', {
                   year: 'numeric',
                   month: 'short',
                   day: 'numeric',
+                  timeZone: 'UTC',
                 })}
               </a>
             ) : (
               <>
                 N/A
+                <span class="sr-only">No commit information available</span>
                 <span class="pointer-events-none absolute bottom-full left-1/2 mb-2 -translate-x-1/2 rounded bg-gray-900 px-2 py-1 text-xs whitespace-nowrap text-white opacity-0 transition-opacity group-hover:opacity-100">
                   No commit information available
                   <span class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900" />

--- a/src/tests/preview.spec.ts
+++ b/src/tests/preview.spec.ts
@@ -11,6 +11,20 @@ test('has component preview', async ({ page }) => {
   await expect(page.locator('component-preview').and(page.locator(FIRST_PREVIEW))).toBeVisible()
 })
 
+test.describe('Component pattern link', () => {
+  test('is visible when pattern metadata exists', async ({ page }) => {
+    await page.goto('/components/application/tabs')
+
+    await expect(page.getByRole('link', { name: 'HyperUX Pattern Available' })).toBeVisible()
+  })
+
+  test('is hidden when pattern metadata does not exist', async ({ page }) => {
+    await page.goto(PAGE_URL)
+
+    await expect(page.getByRole('link', { name: 'HyperUX Pattern Available' })).toHaveCount(0)
+  })
+})
+
 test.describe('Component preview hotlink', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(PAGE_URL)

--- a/src/tests/preview.spec.ts
+++ b/src/tests/preview.spec.ts
@@ -21,7 +21,10 @@ test.describe('Component pattern link', () => {
 
     await patternLink.hover()
 
-    await expect(page.getByText('View related HyperUX pattern documentation')).toBeVisible()
+    await expect(page.getByText('View related HyperUX pattern documentation')).toHaveCSS(
+      'opacity',
+      /^1(\.0+)?$/,
+    )
   })
 
   test('is hidden when pattern metadata does not exist', async ({ page }) => {

--- a/src/tests/preview.spec.ts
+++ b/src/tests/preview.spec.ts
@@ -15,13 +15,20 @@ test.describe('Component pattern link', () => {
   test('is visible when pattern metadata exists', async ({ page }) => {
     await page.goto('/components/application/tabs')
 
-    await expect(page.getByRole('link', { name: 'HyperUX Pattern Available' })).toBeVisible()
+    const patternLink = page.getByRole('link', { name: 'HyperUX Pattern Available' })
+
+    await expect(patternLink).toBeVisible()
+
+    await patternLink.hover()
+
+    await expect(page.getByText('View related HyperUX pattern documentation')).toBeVisible()
   })
 
   test('is hidden when pattern metadata does not exist', async ({ page }) => {
     await page.goto(PAGE_URL)
 
     await expect(page.getByRole('link', { name: 'HyperUX Pattern Available' })).toHaveCount(0)
+    await expect(page.getByText('N/A')).toBeVisible()
   })
 })
 

--- a/src/tests/preview.spec.ts
+++ b/src/tests/preview.spec.ts
@@ -31,7 +31,6 @@ test.describe('Component pattern link', () => {
     await page.goto(PAGE_URL)
 
     await expect(page.getByRole('link', { name: 'HyperUX Pattern Available' })).toHaveCount(0)
-    await expect(page.getByText('N/A')).toBeVisible()
   })
 })
 


### PR DESCRIPTION
Closes #710 

This pull request enhances the component documentation system by introducing new metadata fields and updating the layout to display additional information about each component collection. The changes improve both the data structure and the user interface, making it easier to track pattern links and update history for each component.

**Metadata and Schema Enhancements:**

* Added optional `pattern` and `updated` fields to the collection schema in `src/content.config.ts`, allowing each component collection to specify a related pattern URL and structured update information such as date and commit hash.

* Updated multiple collection `.mdx` files to include the new `pattern` field, linking to relevant HyperUI pattern documentation for components like dropdowns, filters, selects, modals, side menus, tabs, and neobrutalism variants. [[1]](diffhunk://#diff-b6d12f93670a10e55505be6a9bb8df2caa74d24ea969f1a2c84d0287a4297b41R6) [[2]](diffhunk://#diff-2809a79b57d7fc4bfe6b57a401c0e5dd985a850339d36534166402202c530852R7) [[3]](diffhunk://#diff-34974ebec42532c8608ff4f4b6f2cce08d8ece50025950332a801542738be207R6) [[4]](diffhunk://#diff-2db72977e8127a5dde1e3552e32317612e385468bf6a3d18b3128439c572f905R7) [[5]](diffhunk://#diff-2bd2e61ab6b4fc1aaa40151900cadee408fc01409492b87784c07ffc6e9c980fR6) [[6]](diffhunk://#diff-92f154fbb6c65e567a40d3847b3a2233833d59002ca6c6c63387113f8285bbf0R7) [[7]](diffhunk://#diff-c2f1c4b01d0ac53e22d9514fa2083f4d5112835f0f657e93886fe77d3ef5aa5bR7) [[8]](diffhunk://#diff-9a46c056bf6cbc0ed94cc4762777e03119d5b73d8def154ea335c6e3002f6494R7)

**Layout and UI Improvements:**

* Modified `ComponentPost.astro` to accept and use the new `pattern` and `updated` properties, displaying links to pattern documentation and update information (including commit links and formatted dates) in the component details section. [[1]](diffhunk://#diff-aba5148b1c6f531724c78db9c2edb0e9525725b02b9d4ace6b20d8167f80d2c1L16-R17) [[2]](diffhunk://#diff-aba5148b1c6f531724c78db9c2edb0e9525725b02b9d4ace6b20d8167f80d2c1L95-R159)

* Replaced the dark mode indicator icon from `Moon` to `Dot` for a more neutral visual cue in the component details area.

**Minor Adjustments:**

* Commented out a pattern link in the steps collection, possibly for future use or pending documentation.