### PR TITLE
Update - Deduplicate ToolCard link/non-link branch markup

### DIFF
--- a/src/components/ToolCard.astro
+++ b/src/components/ToolCard.astro
@@ -13,42 +13,26 @@ interface Props {
 
 const { title, status, description, href, headingLevel = 'h2' } = Astro.props
 
+const isLink = Boolean(href)
+
+const WrapperTag = isLink ? 'a' : 'div'
+const HeadingTag = headingLevel
+
 const cardClasses =
   'flex h-full flex-col rounded-lg border border-gray-200 bg-white p-6 transition-colors'
 const linkClasses = 'group hover:border-gray-300 hover:bg-gray-50'
-const headingClasses = href
+const wrapperClasses = isLink ? `${cardClasses} ${linkClasses}` : cardClasses
+const headingClasses = isLink
   ? 'text-lg font-medium text-gray-900 group-hover:text-gray-700'
   : 'text-lg font-medium text-gray-900'
 ---
 
-{
-  href ? (
-    <a href={href} class={`${cardClasses} ${linkClasses}`}>
-      <div class="flex items-start justify-between gap-4">
-        {headingLevel === 'h2' ? (
-          <h2 class={headingClasses}>{title}</h2>
-        ) : (
-          <h3 class={headingClasses}>{title}</h3>
-        )}
+<WrapperTag href={href} class={wrapperClasses}>
+  <div class="flex items-start justify-between gap-4">
+    <HeadingTag class={headingClasses}>{title}</HeadingTag>
 
-        <StatusBadge {status} />
-      </div>
+    <StatusBadge {status} />
+  </div>
 
-      <p class="mt-2 text-sm text-gray-600">{description}</p>
-    </a>
-  ) : (
-    <div class={cardClasses}>
-      <div class="flex items-start justify-between gap-4">
-        {headingLevel === 'h2' ? (
-          <h2 class={headingClasses}>{title}</h2>
-        ) : (
-          <h3 class={headingClasses}>{title}</h3>
-        )}
-
-        <StatusBadge {status} />
-      </div>
-
-      <p class="mt-2 text-sm text-gray-600">{description}</p>
-    </div>
-  )
-}
+  <p class="mt-2 text-sm text-gray-600">{description}</p>
+</WrapperTag>


### PR DESCRIPTION
Closes #724

## What

`ToolCard.astro` had two near-identical render branches — one for an `<a>`, one for a `<div>` — duplicating the entire inner structure (heading, badge, description).

## How

Collapse them into a single block using Astro's dynamic tag support:

- `WrapperTag` resolves to `a` or `div` based on whether `href` is set
- `HeadingTag` resolves directly from `headingLevel` (removes the `h2`/`h3` ternary duplication too)
- Link-only classes are conditionally appended to the wrapper

When rendering the `div` variant, `href={undefined}` is omitted by Astro, so the output is byte-identical to before (verified against the built `/tools` page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)