### PR TITLE
Bugfix - Source copied component HTML from build-time file, not live iframe

### DIFF
--- a/src/components/ComponentPreview.astro
+++ b/src/components/ComponentPreview.astro
@@ -1,4 +1,6 @@
 ---
+import { readComponentMarkup } from '../utils/componentMarkup'
+
 interface Props {
   src: string
   title: string
@@ -8,6 +10,8 @@ interface Props {
 }
 
 const { src, title, dark = false, index = 1, wrapper = '' } = Astro.props
+
+const sourceHtml = readComponentMarkup(src)
 ---
 
 <component-preview data-src={src} class="block">
@@ -27,7 +31,7 @@ const { src, title, dark = false, index = 1, wrapper = '' } = Astro.props
     data-preview="true"
     class="prose prose-pre:m-0 prose-pre:rounded-none max-w-none data-[preview=true]:hidden"
   >
-    <pre data-html></pre>
+    <pre data-html set:text={sourceHtml} />
   </div>
 </component-preview>
 
@@ -98,16 +102,10 @@ const { src, title, dark = false, index = 1, wrapper = '' } = Astro.props
       this.viewHandler = (viewEvent) => {
         const isPreviewing = viewEvent.detail.previewing
 
-        const previewEls = this.querySelectorAll('[data-preview]')
+        const previewToggleElements = this.querySelectorAll('[data-preview]')
 
-        const contentHtml = this.getContent()
-
-        if (contentHtml && this.previewEl) {
-          this.previewEl.textContent = contentHtml
-        }
-
-        previewEls.forEach((previewEl) => {
-          previewEl.setAttribute('data-preview', isPreviewing ? 'true' : 'false')
+        previewToggleElements.forEach((previewToggleElement) => {
+          previewToggleElement.setAttribute('data-preview', isPreviewing ? 'true' : 'false')
         })
       }
 
@@ -125,23 +123,13 @@ const { src, title, dark = false, index = 1, wrapper = '' } = Astro.props
         return this.contentHtml
       }
 
-      if (this.iframeEl?.contentDocument) {
-        const docClone = this.iframeEl.contentDocument.cloneNode(true) as Document
-
-        this.contentHtml = this.sanitizeContent(docClone.body.innerHTML)
+      if (this.previewEl) {
+        this.contentHtml = this.previewEl.textContent?.trim() || null
 
         return this.contentHtml
       }
 
       return null
-    }
-
-    private sanitizeContent(contentHtml: string): string {
-      return contentHtml
-        .split('\n')
-        .map((htmlLine) => htmlLine.replace(/^\s{4}/, ''))
-        .join('\n')
-        .trim()
     }
   }
 

--- a/src/components/TypographyMapper.astro
+++ b/src/components/TypographyMapper.astro
@@ -1,6 +1,5 @@
 ---
 import { MoveRight, Percent } from '@lucide/astro'
-
 ---
 
 <typography-mapper class="flex flex-1 flex-col">
@@ -87,7 +86,6 @@ import { MoveRight, Percent } from '@lucide/astro'
         <option value="900">Black (900)</option>
       </select>
     </label>
-
   </div>
 
   <div class="mt-4 flex flex-1 flex-col">
@@ -115,10 +113,7 @@ import { MoveRight, Percent } from '@lucide/astro'
                 class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
               ></span>
 
-              <span
-                data-letter-spacing-label-badge
-                class="hidden"
-              ></span>
+              <span data-letter-spacing-label-badge class="hidden"></span>
             </div>
           </div>
 
@@ -246,18 +241,13 @@ import { MoveRight, Percent } from '@lucide/astro'
           <pre data-config-pre class="overflow-x-auto p-4 font-mono text-sm text-gray-900"></pre>
 
           <div class="absolute top-3 right-3">
-            <button
-              data-copy-config-button
-              type="button"
-              class="hidden"
-            >
+            <button data-copy-config-button type="button" class="hidden">
               <span data-copy-config-button-text>Copy</span>
               <span data-copy-config-live-region aria-live="polite" class="sr-only"></span>
             </button>
           </div>
         </div>
       </div>
-
     </div>
   </div>
 </typography-mapper>
@@ -544,7 +534,6 @@ import { MoveRight, Percent } from '@lucide/astro'
     return 'Arbitrary font size and line height'
   }
 
-
   function buildThemeConfig(
     mappingResult: TypographyMappingResult,
     fontSizePixelValue: number,
@@ -636,7 +625,9 @@ import { MoveRight, Percent } from '@lucide/astro'
       await navigator.clipboard.writeText(textToCopy)
       buttonTextElement.textContent = 'Copied'
       liveRegionElement.textContent = 'Copied to clipboard.'
-      if (existingTimerId) { clearTimeout(existingTimerId) }
+      if (existingTimerId) {
+        clearTimeout(existingTimerId)
+      }
       return setTimeout(() => {
         buttonTextElement.textContent = 'Copy'
         liveRegionElement.textContent = ''
@@ -758,7 +749,9 @@ import { MoveRight, Percent } from '@lucide/astro'
       configCopyButtonElement.addEventListener('click', async () => {
         const configPreElement = this.querySelector<HTMLPreElement>('[data-config-pre]')!
         const configText = configPreElement.textContent ?? ''
-        if (!configText.trim()) { return }
+        if (!configText.trim()) {
+          return
+        }
         this.configCopyTimerId = await copyTextToClipboard(
           configText,
           configCopyButtonTextElement,
@@ -774,7 +767,9 @@ import { MoveRight, Percent } from '@lucide/astro'
       const copyLiveRegionElement = this.querySelector<HTMLElement>('[data-copy-live-region]')!
 
       copyButtonElement.addEventListener('click', async () => {
-        if (!this.currentCombinedClass) { return }
+        if (!this.currentCombinedClass) {
+          return
+        }
         this.clipboardCopyTimerId = await copyTextToClipboard(
           this.currentCombinedClass,
           copyButtonTextElement,
@@ -807,7 +802,9 @@ import { MoveRight, Percent } from '@lucide/astro'
       const customClassName = classNameInputElement.value.trim() || null
 
       const fontWeightUtilityClass =
-        !customClassName && fontWeightValue !== '400' ? FONT_WEIGHT_UTILITY_MAP[fontWeightValue] : ''
+        !customClassName && fontWeightValue !== '400'
+          ? FONT_WEIGHT_UTILITY_MAP[fontWeightValue]
+          : ''
       const combinedClassWithWeight = fontWeightUtilityClass
         ? `${mappingResult.combinedClass} ${fontWeightUtilityClass}`
         : mappingResult.combinedClass
@@ -926,7 +923,6 @@ import { MoveRight, Percent } from '@lucide/astro'
         ? 'inline-flex items-center justify-center rounded-md bg-black px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-gray-800'
         : 'hidden'
     }
-
   }
 
   customElements.define('typography-mapper', TypographyMapper)

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -50,7 +50,9 @@ const neobrutalism = neobrutalismRaw
 
   <main id="main-content" class="mx-auto max-w-7xl divide-y divide-gray-200 px-4">
     <section class="py-16">
-      <div class="flex items-center justify-between gap-8 rounded-lg border border-gray-200 bg-gray-50 p-8">
+      <div
+        class="flex items-center justify-between gap-8 rounded-lg border border-gray-200 bg-gray-50 p-8"
+      >
         <div>
           <h2 class="text-2xl font-medium">HyperUI Tools</h2>
 
@@ -61,7 +63,7 @@ const neobrutalism = neobrutalismRaw
 
         <a
           href="/tools"
-          class="shrink-0 inline-flex items-center justify-center gap-2 rounded-md border border-gray-900 bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:border-gray-800 hover:bg-gray-800"
+          class="inline-flex shrink-0 items-center justify-center gap-2 rounded-md border border-gray-900 bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:border-gray-800 hover:bg-gray-800"
         >
           Browse tools
         </a>

--- a/src/utils/componentMarkup.ts
+++ b/src/utils/componentMarkup.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const BODY_CONTENT_PATTERN = /<body[^>]*>([\s\S]*?)<\/body>/i
+
+export function readComponentMarkup(componentSrc: string): string {
+  try {
+    const componentFilePath = join(process.cwd(), 'public', componentSrc)
+    const rawFileContent = readFileSync(componentFilePath, 'utf-8')
+
+    const bodyContentMatch = rawFileContent.match(BODY_CONTENT_PATTERN)
+
+    if (!bodyContentMatch) {
+      return ''
+    }
+
+    return bodyContentMatch[1]
+      .split('\n')
+      .map((markupLine) => markupLine.replace(/^\s{4}/, ''))
+      .join('\n')
+      .trim()
+  } catch {
+    return ''
+  }
+}

--- a/src/utils/componentMarkup.ts
+++ b/src/utils/componentMarkup.ts
@@ -1,21 +1,21 @@
 const BODY_CONTENT_PATTERN = /<body[^>]*>([\s\S]*?)<\/body>/i
 
-const rawComponentFiles = import.meta.glob('../../public/examples/**/*.html', {
+const rawComponentFileMap = import.meta.glob('../../public/examples/**/*.html', {
   query: '?raw',
   import: 'default',
   eager: true,
 }) as Record<string, string>
 
-const componentMarkupBySrc: Record<string, string> = {}
+const componentMarkupMap: Record<string, string> = {}
 
-for (const [filePath, fileContent] of Object.entries(rawComponentFiles)) {
+for (const [filePath, fileContent] of Object.entries(rawComponentFileMap)) {
   const normalizedSrc = filePath.replace(/^.*\/public/, '')
 
-  componentMarkupBySrc[normalizedSrc] = fileContent
+  componentMarkupMap[normalizedSrc] = fileContent
 }
 
 export function readComponentMarkup(componentSrc: string): string {
-  const rawFileContent = componentMarkupBySrc[componentSrc]
+  const rawFileContent = componentMarkupMap[componentSrc]
 
   if (!rawFileContent) {
     return ''

--- a/src/utils/componentMarkup.ts
+++ b/src/utils/componentMarkup.ts
@@ -1,25 +1,35 @@
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
-
 const BODY_CONTENT_PATTERN = /<body[^>]*>([\s\S]*?)<\/body>/i
 
+const rawComponentFiles = import.meta.glob('../../public/examples/**/*.html', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+const componentMarkupBySrc: Record<string, string> = {}
+
+for (const [filePath, fileContent] of Object.entries(rawComponentFiles)) {
+  const normalizedSrc = filePath.replace(/^.*\/public/, '')
+
+  componentMarkupBySrc[normalizedSrc] = fileContent
+}
+
 export function readComponentMarkup(componentSrc: string): string {
-  try {
-    const componentFilePath = join(process.cwd(), 'public', componentSrc)
-    const rawFileContent = readFileSync(componentFilePath, 'utf-8')
+  const rawFileContent = componentMarkupBySrc[componentSrc]
 
-    const bodyContentMatch = rawFileContent.match(BODY_CONTENT_PATTERN)
-
-    if (!bodyContentMatch) {
-      return ''
-    }
-
-    return bodyContentMatch[1]
-      .split('\n')
-      .map((markupLine) => markupLine.replace(/^\s{4}/, ''))
-      .join('\n')
-      .trim()
-  } catch {
+  if (!rawFileContent) {
     return ''
   }
+
+  const bodyContentMatch = rawFileContent.match(BODY_CONTENT_PATTERN)
+
+  if (!bodyContentMatch) {
+    return ''
+  }
+
+  return bodyContentMatch[1]
+    .split('\n')
+    .map((markupLine) => markupLine.replace(/^\s{4}/, ''))
+    .join('\n')
+    .trim()
 }


### PR DESCRIPTION
## Problem

Users reported a `<script src="/cdn-cgi/challenge-platform/scripts/...">` and a hidden `<iframe>` appearing in the HTML when previewing/copying components. This is **Cloudflare's JS Detection** (Bot Fight Mode) injecting into HTML responses at the edge — not anything in the repo.

The copy/code-view path serialized the **live iframe document** (`iframeEl.contentDocument` → `body.innerHTML`), so whatever Cloudflare injected at runtime was scooped up into the copied output.

## Fix

Inline the authored component markup from `public/examples/**` at **build time** and embed it into the `<pre>`. `getContent()` now reads that embedded source instead of cloning the live iframe.

- New `src/utils/componentMarkup.ts` — loads every example via `import.meta.glob('../../public/examples/**/*.html', { query: '?raw', eager: true })`, keyed by `src`. `readComponentMarkup(src)` extracts `<body>` content, dedents one level, trims.
- `ComponentPreview.astro` — embeds source via `<pre set:text={sourceHtml}>`; removed the now-redundant `sanitizeContent` helper and the `viewHandler` text rewrite.

## Why this approach

- **Immune to all runtime injection** — Cloudflare edge *and* browser extensions — because the string is materialized at build before any live document exists.
- A runtime `fetch()` would not fix it: Cloudflare injects into any `text/html` response, including fetches.
- **`import.meta.glob ?raw`, not `node:fs`** — the Cloudflare adapter prerenders in a Workers runtime with no `node:fs`, so a render-time `readFileSync` throws `No such module "node:fs"`. Vite's glob inlines the file contents as strings at bundle time, sidestepping that.
- **Page stays fully static** — the inlined strings are baked into the generated HTML; no runtime/server call, and nothing extra ships to the client (build-time/prerender only).

## Notes

- RTL toggle was checked and is not a vector — it only `postMessage`s and sets `dir` on `<html>`, outside the copied `body` content.
- A Cloudflare rule disabling Bot Fight Mode for `/examples/*` is optional defense-in-depth (keeps the live preview clean too) but no longer required to fix the copy output.
- Includes a small unrelated Prettier-formatting commit (`TypographyMapper.astro`, `index.astro`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)