### PR TITLE
Update - Extract shared clipboard copy utility to src/lib/clipboard.ts

### DIFF
--- a/src/components/DarkModeGenerator.astro
+++ b/src/components/DarkModeGenerator.astro
@@ -23,6 +23,7 @@ import DarkModeInspector from './DarkModeInspector.astro'
     exportConfig,
     importConfig,
   } from '../lib/dark-mode/config.js'
+  import { copyTextToClipboard } from '../lib/clipboard.js'
   import { transformHtmlDom } from '../lib/dark-mode/transform-html.js'
   import { buildPreviewDocument } from '../lib/dark-mode/preview-document.js'
   import {
@@ -306,34 +307,21 @@ import DarkModeInspector from './DarkModeInspector.astro'
         },
       )
 
-      const copyButton = this.querySelector<HTMLButtonElement>('[data-copy]')!
-      const copyButtonText = this.querySelector<HTMLElement>('[data-copy-text]')!
-      const copyLiveRegion = this.querySelector<HTMLElement>('[data-copy-polite]')!
+      const copyButtonElement = this.querySelector<HTMLButtonElement>('[data-copy]')!
+      const copyButtonTextElement = this.querySelector<HTMLElement>('[data-copy-text]')!
+      const copyLiveRegionElement = this.querySelector<HTMLElement>('[data-copy-polite]')!
 
-      copyButton.addEventListener('click', async () => {
+      copyButtonElement.addEventListener('click', async () => {
         const outputText = this.querySelector<HTMLPreElement>('[data-output]')!.textContent ?? ''
         if (!outputText.trim()) {
           return
         }
-
-        try {
-          await navigator.clipboard.writeText(outputText)
-
-          copyButtonText.textContent = 'Copied'
-          copyLiveRegion.textContent = 'Copied to clipboard.'
-          copyButton.setAttribute('aria-pressed', 'true')
-
-          if (this.clipboardCopyTimer) {
-            clearTimeout(this.clipboardCopyTimer)
-          }
-          this.clipboardCopyTimer = setTimeout(() => {
-            copyButtonText.textContent = 'Copy'
-            copyLiveRegion.textContent = ''
-            copyButton.setAttribute('aria-pressed', 'false')
-          }, 1500)
-        } catch {
-          //
-        }
+        this.clipboardCopyTimer = await copyTextToClipboard(outputText, {
+          buttonTextElement: copyButtonTextElement,
+          liveRegionElement: copyLiveRegionElement,
+          buttonElement: copyButtonElement,
+          existingTimerId: this.clipboardCopyTimer,
+        })
       })
 
       this.querySelectorAll<HTMLButtonElement>('[data-preview-mode]').forEach((modeButton) => {

--- a/src/components/PreviewCopy.astro
+++ b/src/components/PreviewCopy.astro
@@ -24,6 +24,8 @@ const { src } = Astro.props
 </preview-copy>
 
 <script>
+  import { applyCopiedButtonState } from '../lib/clipboard.js'
+
   class PreviewCopy extends HTMLElement {
     private isProcessing = false
     private contentSrc: string | null = null
@@ -58,31 +60,21 @@ const { src } = Astro.props
 
         this.isProcessing = true
 
-        if (this.timeoutId !== null) {
-          clearTimeout(this.timeoutId)
-        }
-
         document.dispatchEvent(
           new CustomEvent(`preview:copy:${this.contentSrc}`, {
             bubbles: true,
           }),
         )
 
-        buttonText.textContent = 'Copied'
-        politeEl.textContent = 'Copied to clipboard.'
-
-        buttonEl.setAttribute('aria-pressed', 'true')
-
-        this.timeoutId = globalThis.setTimeout(() => {
-          if (this.isConnected) {
-            buttonText.textContent = 'Copy'
-            politeEl.textContent = ''
-
-            buttonEl.setAttribute('aria-pressed', 'false')
-          }
-
-          this.isProcessing = false
-        }, 1500)
+        this.timeoutId = applyCopiedButtonState({
+          buttonTextElement: buttonText as HTMLElement,
+          liveRegionElement: politeEl as HTMLElement,
+          buttonElement: buttonEl,
+          existingTimerId: this.timeoutId,
+          onReset: () => {
+            this.isProcessing = false
+          },
+        })
       }
 
       buttonEl.addEventListener('click', this.clickHandler)

--- a/src/components/TypographyMapper.astro
+++ b/src/components/TypographyMapper.astro
@@ -253,6 +253,8 @@ import { MoveRight, Percent } from '@lucide/astro'
 </typography-mapper>
 
 <script>
+  import { copyTextToClipboard } from '../lib/clipboard.js'
+
   type FontSizeScaleEntry = {
     pixelValue: number
     remValue: string
@@ -613,30 +615,6 @@ import { MoveRight, Percent } from '@lucide/astro'
     }
   }
 
-  const COPY_RESET_DELAY_MS = 1500
-
-  async function copyTextToClipboard(
-    textToCopy: string,
-    buttonTextElement: HTMLElement,
-    liveRegionElement: HTMLElement,
-    existingTimerId: ReturnType<typeof setTimeout> | null,
-  ): Promise<ReturnType<typeof setTimeout> | null> {
-    try {
-      await navigator.clipboard.writeText(textToCopy)
-      buttonTextElement.textContent = 'Copied'
-      liveRegionElement.textContent = 'Copied to clipboard.'
-      if (existingTimerId) {
-        clearTimeout(existingTimerId)
-      }
-      return setTimeout(() => {
-        buttonTextElement.textContent = 'Copy'
-        liveRegionElement.textContent = ''
-      }, COPY_RESET_DELAY_MS)
-    } catch {
-      return existingTimerId
-    }
-  }
-
   class TypographyMapper extends HTMLElement {
     private clipboardCopyTimerId: ReturnType<typeof setTimeout> | null = null
     private configCopyTimerId: ReturnType<typeof setTimeout> | null = null
@@ -792,12 +770,11 @@ import { MoveRight, Percent } from '@lucide/astro'
         if (!configText.trim()) {
           return
         }
-        this.configCopyTimerId = await copyTextToClipboard(
-          configText,
-          this.copyConfigButtonTextElement,
-          this.copyConfigLiveRegionElement,
-          this.configCopyTimerId,
-        )
+        this.configCopyTimerId = await copyTextToClipboard(configText, {
+          buttonTextElement: this.copyConfigButtonTextElement,
+          liveRegionElement: this.copyConfigLiveRegionElement,
+          existingTimerId: this.configCopyTimerId,
+        })
       })
     }
 
@@ -806,12 +783,11 @@ import { MoveRight, Percent } from '@lucide/astro'
         if (!this.currentCombinedClass) {
           return
         }
-        this.clipboardCopyTimerId = await copyTextToClipboard(
-          this.currentCombinedClass,
-          this.copyButtonTextElement,
-          this.copyLiveRegionElement,
-          this.clipboardCopyTimerId,
-        )
+        this.clipboardCopyTimerId = await copyTextToClipboard(this.currentCombinedClass, {
+          buttonTextElement: this.copyButtonTextElement,
+          liveRegionElement: this.copyLiveRegionElement,
+          existingTimerId: this.clipboardCopyTimerId,
+        })
       })
     }
 

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,43 @@
+const COPY_RESET_DELAY_MS = 1500
+
+type CopyButtonStateOptions = {
+  buttonTextElement: HTMLElement
+  liveRegionElement: HTMLElement
+  buttonElement?: HTMLButtonElement
+  existingTimerId: ReturnType<typeof setTimeout> | null
+  onReset?: () => void
+}
+
+export function applyCopiedButtonState(
+  copyButtonStateOptions: CopyButtonStateOptions,
+): ReturnType<typeof setTimeout> {
+  const { buttonTextElement, liveRegionElement, buttonElement, existingTimerId, onReset } =
+    copyButtonStateOptions
+
+  buttonTextElement.textContent = 'Copied'
+  liveRegionElement.textContent = 'Copied to clipboard.'
+  buttonElement?.setAttribute('aria-pressed', 'true')
+
+  if (existingTimerId) {
+    clearTimeout(existingTimerId)
+  }
+
+  return setTimeout(() => {
+    buttonTextElement.textContent = 'Copy'
+    liveRegionElement.textContent = ''
+    buttonElement?.setAttribute('aria-pressed', 'false')
+    onReset?.()
+  }, COPY_RESET_DELAY_MS)
+}
+
+export async function copyTextToClipboard(
+  textToCopy: string,
+  copyButtonStateOptions: CopyButtonStateOptions,
+): Promise<ReturnType<typeof setTimeout> | null> {
+  try {
+    await navigator.clipboard.writeText(textToCopy)
+    return applyCopiedButtonState(copyButtonStateOptions)
+  } catch {
+    return copyButtonStateOptions.existingTimerId
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `src/lib/clipboard.ts` exporting `copyTextToClipboard` (clipboard write + UI reset) and `applyCopiedButtonState` (UI reset only, for components that dispatch events instead of writing directly)
- Removes the duplicated copy pattern from `TypographyMapper.astro`, `DarkModeGenerator.astro`, and `PreviewCopy.astro`
- The delay, feedback text, and `aria-pressed` behaviour now live in one place

## Test plan

- [x] Copy button on the Typography Mapper tool shows "Copied" then resets to "Copy"
- [x] Copy config button on the Typography Mapper tool works the same way
- [x] Copy button on the Dark Mode Generator tool shows "Copied" then resets, with `aria-pressed` toggling correctly
- [x] Copy HTML button on component previews shows "Copied" then resets, with `aria-pressed` toggling correctly

Closes #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)