### PR TITLE
Update - Fix accessibility issues across application component examples

### DIFF
--- a/public/examples/application/badges/2-dark.html
+++ b/public/examples/application/badges/2-dark.html
@@ -11,6 +11,7 @@
       class="inline-flex items-center justify-center rounded-full bg-purple-100 px-2.5 py-0.5 text-purple-700 dark:bg-purple-700 dark:text-purple-100"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
@@ -32,6 +33,7 @@
       class="inline-flex items-center justify-center rounded-full border border-purple-500 px-2.5 py-0.5 text-purple-700 dark:text-purple-100"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/public/examples/application/badges/2.html
+++ b/public/examples/application/badges/2.html
@@ -11,6 +11,7 @@
       class="inline-flex items-center justify-center rounded-full bg-purple-100 px-2.5 py-0.5 text-purple-700"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
@@ -32,6 +33,7 @@
       class="inline-flex items-center justify-center rounded-full border border-purple-500 px-2.5 py-0.5 text-purple-700"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/public/examples/application/badges/3-dark.html
+++ b/public/examples/application/badges/3-dark.html
@@ -18,6 +18,7 @@
         <span class="sr-only">Remove badge</span>
 
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -41,6 +42,7 @@
         <span class="sr-only">Remove badge</span>
 
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/badges/3.html
+++ b/public/examples/application/badges/3.html
@@ -18,6 +18,7 @@
         <span class="sr-only">Remove badge</span>
 
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -41,6 +42,7 @@
         <span class="sr-only">Remove badge</span>
 
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/badges/4-dark.html
+++ b/public/examples/application/badges/4-dark.html
@@ -11,6 +11,7 @@
       class="inline-flex items-center justify-center rounded-full bg-purple-100 px-2.5 py-1 text-purple-700 dark:bg-purple-700 dark:text-purple-100"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
@@ -30,6 +31,7 @@
       class="inline-flex items-center justify-center rounded-full border border-purple-500 px-2.5 py-1 text-purple-700 dark:text-purple-100"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/public/examples/application/badges/4.html
+++ b/public/examples/application/badges/4.html
@@ -11,6 +11,7 @@
       class="inline-flex items-center justify-center rounded-full bg-purple-100 px-2.5 py-1 text-purple-700"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
@@ -30,6 +31,7 @@
       class="inline-flex items-center justify-center rounded-full border border-purple-500 px-2.5 py-1 text-purple-700"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/public/examples/application/badges/5-dark.html
+++ b/public/examples/application/badges/5-dark.html
@@ -11,6 +11,7 @@
       class="inline-flex items-center justify-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-emerald-700 dark:bg-emerald-700 dark:text-emerald-100"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
@@ -32,6 +33,7 @@
       class="inline-flex items-center justify-center rounded-full border border-emerald-500 px-2.5 py-0.5 text-emerald-700 dark:text-emerald-100"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
@@ -53,6 +55,7 @@
       class="inline-flex items-center justify-center rounded-full bg-amber-100 px-2.5 py-0.5 text-amber-700 dark:bg-amber-700 dark:text-amber-100"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
@@ -74,6 +77,7 @@
       class="inline-flex items-center justify-center rounded-full border border-amber-500 px-2.5 py-0.5 text-amber-700 dark:text-amber-100"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
@@ -95,6 +99,7 @@
       class="inline-flex items-center justify-center rounded-full bg-red-100 px-2.5 py-0.5 text-red-700 dark:bg-red-700 dark:text-red-100"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
@@ -116,6 +121,7 @@
       class="inline-flex items-center justify-center rounded-full border border-red-500 px-2.5 py-0.5 text-red-700 dark:text-red-100"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/public/examples/application/badges/5.html
+++ b/public/examples/application/badges/5.html
@@ -11,6 +11,7 @@
       class="inline-flex items-center justify-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-emerald-700"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
@@ -32,6 +33,7 @@
       class="inline-flex items-center justify-center rounded-full border border-emerald-500 px-2.5 py-0.5 text-emerald-700"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
@@ -53,6 +55,7 @@
       class="inline-flex items-center justify-center rounded-full bg-amber-100 px-2.5 py-0.5 text-amber-700"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
@@ -74,6 +77,7 @@
       class="inline-flex items-center justify-center rounded-full border border-amber-500 px-2.5 py-0.5 text-amber-700"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
@@ -95,6 +99,7 @@
       class="inline-flex items-center justify-center rounded-full bg-red-100 px-2.5 py-0.5 text-red-700"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
@@ -116,6 +121,7 @@
       class="inline-flex items-center justify-center rounded-full border border-red-500 px-2.5 py-0.5 text-red-700"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/public/examples/application/breadcrumbs/1-dark.html
+++ b/public/examples/application/breadcrumbs/1-dark.html
@@ -17,6 +17,7 @@
 
         <li class="rtl:rotate-180">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-4"
             viewBox="0 0 20 20"
@@ -38,6 +39,7 @@
 
         <li class="rtl:rotate-180">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-4"
             viewBox="0 0 20 20"

--- a/public/examples/application/breadcrumbs/1.html
+++ b/public/examples/application/breadcrumbs/1.html
@@ -15,6 +15,7 @@
 
         <li class="rtl:rotate-180">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-4"
             viewBox="0 0 20 20"
@@ -34,6 +35,7 @@
 
         <li class="rtl:rotate-180">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-4"
             viewBox="0 0 20 20"

--- a/public/examples/application/breadcrumbs/2-dark.html
+++ b/public/examples/application/breadcrumbs/2-dark.html
@@ -16,6 +16,7 @@
             aria-label="Home"
           >
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               class="size-4"
               fill="none"
@@ -34,6 +35,7 @@
 
         <li class="rtl:rotate-180">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-4"
             viewBox="0 0 20 20"
@@ -55,6 +57,7 @@
 
         <li class="rtl:rotate-180">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-4"
             viewBox="0 0 20 20"

--- a/public/examples/application/breadcrumbs/2.html
+++ b/public/examples/application/breadcrumbs/2.html
@@ -12,6 +12,7 @@
         <li>
           <a href="#" class="block transition-colors hover:text-gray-900" aria-label="Home">
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               class="size-4"
               fill="none"
@@ -30,6 +31,7 @@
 
         <li class="rtl:rotate-180">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-4"
             viewBox="0 0 20 20"
@@ -49,6 +51,7 @@
 
         <li class="rtl:rotate-180">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-4"
             viewBox="0 0 20 20"

--- a/public/examples/application/breadcrumbs/3-dark.html
+++ b/public/examples/application/breadcrumbs/3-dark.html
@@ -17,6 +17,7 @@
 
         <li class="rtl:rotate-180">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
@@ -36,6 +37,7 @@
 
         <li class="rtl:rotate-180">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"

--- a/public/examples/application/breadcrumbs/3.html
+++ b/public/examples/application/breadcrumbs/3.html
@@ -15,6 +15,7 @@
 
         <li class="rtl:rotate-180">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
@@ -32,6 +33,7 @@
 
         <li class="rtl:rotate-180">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"

--- a/public/examples/application/breadcrumbs/4-dark.html
+++ b/public/examples/application/breadcrumbs/4-dark.html
@@ -16,6 +16,7 @@
             aria-label="Home"
           >
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               class="size-4"
               fill="none"
@@ -34,6 +35,7 @@
 
         <li class="rtl:rotate-180">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
@@ -53,6 +55,7 @@
 
         <li class="rtl:rotate-180">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"

--- a/public/examples/application/breadcrumbs/4.html
+++ b/public/examples/application/breadcrumbs/4.html
@@ -12,6 +12,7 @@
         <li>
           <a href="#" class="block transition-colors hover:text-gray-900" aria-label="Home">
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               class="size-4"
               fill="none"
@@ -30,6 +31,7 @@
 
         <li class="rtl:rotate-180">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
@@ -47,6 +49,7 @@
 
         <li class="rtl:rotate-180">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"

--- a/public/examples/application/button-groups/2-dark.html
+++ b/public/examples/application/button-groups/2-dark.html
@@ -10,8 +10,10 @@
     <div class="inline-flex">
       <button
         class="rounded-s-sm border border-gray-200 px-3 py-2 text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:z-10 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white dark:focus:ring-offset-gray-900"
+        aria-label="View"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -34,8 +36,10 @@
 
       <button
         class="-ms-px border border-gray-200 px-3 py-2 text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:z-10 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white dark:focus:ring-offset-gray-900"
+        aria-label="Edit"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -53,8 +57,10 @@
 
       <button
         class="-ms-px rounded-e-sm border border-gray-200 px-3 py-2 text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:z-10 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white dark:focus:ring-offset-gray-900"
+        aria-label="Delete"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/button-groups/2.html
+++ b/public/examples/application/button-groups/2.html
@@ -10,8 +10,10 @@
     <div class="inline-flex">
       <button
         class="rounded-s-sm border border-gray-200 px-3 py-2 text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:z-10 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50"
+        aria-label="View"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -34,8 +36,10 @@
 
       <button
         class="-ms-px border border-gray-200 px-3 py-2 text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:z-10 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50"
+        aria-label="Edit"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -53,8 +57,10 @@
 
       <button
         class="-ms-px rounded-e-sm border border-gray-200 px-3 py-2 text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:z-10 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50"
+        aria-label="Delete"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/button-groups/3-dark.html
+++ b/public/examples/application/button-groups/3-dark.html
@@ -16,8 +16,10 @@
 
       <button
         class="-ms-px rounded-e-sm border border-gray-200 px-3 py-2 text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:z-10 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white dark:focus:ring-offset-gray-900"
+        aria-label="View"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/button-groups/3.html
+++ b/public/examples/application/button-groups/3.html
@@ -16,8 +16,10 @@
 
       <button
         class="-ms-px rounded-e-sm border border-gray-200 px-3 py-2 text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:z-10 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50"
+        aria-label="View"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/button-groups/4-dark.html
+++ b/public/examples/application/button-groups/4-dark.html
@@ -10,8 +10,10 @@
     <div class="inline-flex gap-2">
       <button
         class="rounded-sm border border-gray-200 p-2 text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white dark:focus:ring-offset-gray-900"
+        aria-label="Grid view"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -29,8 +31,10 @@
 
       <button
         class="rounded-sm border border-gray-200 p-2 text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white dark:focus:ring-offset-gray-900"
+        aria-label="List view"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/button-groups/4.html
+++ b/public/examples/application/button-groups/4.html
@@ -10,8 +10,10 @@
     <div class="inline-flex gap-2">
       <button
         class="rounded-sm border border-gray-200 p-2 text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50"
+        aria-label="Grid view"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -29,8 +31,10 @@
 
       <button
         class="rounded-sm border border-gray-200 p-2 text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50"
+        aria-label="List view"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/button-groups/5-dark.html
+++ b/public/examples/application/button-groups/5-dark.html
@@ -10,8 +10,10 @@
     <div class="inline-flex">
       <button
         class="rounded-s-sm border border-gray-200 p-2 text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:z-10 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white dark:focus:ring-offset-gray-900"
+        aria-label="Grid view"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -29,8 +31,10 @@
 
       <button
         class="-ms-px rounded-e-sm border border-gray-200 p-2 text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:z-10 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white dark:focus:ring-offset-gray-900"
+        aria-label="List view"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/button-groups/5.html
+++ b/public/examples/application/button-groups/5.html
@@ -10,8 +10,10 @@
     <div class="inline-flex">
       <button
         class="rounded-s-sm border border-gray-200 p-2 text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:z-10 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50"
+        aria-label="Grid view"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -29,8 +31,10 @@
 
       <button
         class="-ms-px rounded-e-sm border border-gray-200 p-2 text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:z-10 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50"
+        aria-label="List view"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/dropdown/1-dark.html
+++ b/public/examples/application/dropdown/1-dark.html
@@ -24,6 +24,7 @@
           aria-label="Menu"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"

--- a/public/examples/application/dropdown/1.html
+++ b/public/examples/application/dropdown/1.html
@@ -24,6 +24,7 @@
           aria-label="Menu"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"

--- a/public/examples/application/dropdown/2-dark.html
+++ b/public/examples/application/dropdown/2-dark.html
@@ -24,6 +24,7 @@
           aria-label="Menu"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"

--- a/public/examples/application/dropdown/2.html
+++ b/public/examples/application/dropdown/2.html
@@ -24,6 +24,7 @@
           aria-label="Menu"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"

--- a/public/examples/application/dropdown/3-dark.html
+++ b/public/examples/application/dropdown/3-dark.html
@@ -24,6 +24,7 @@
           aria-label="Menu"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"

--- a/public/examples/application/dropdown/3.html
+++ b/public/examples/application/dropdown/3.html
@@ -24,6 +24,7 @@
           aria-label="Menu"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"

--- a/public/examples/application/empty-states/1-dark.html
+++ b/public/examples/application/empty-states/1-dark.html
@@ -9,6 +9,7 @@
   <body class="flex min-h-screen items-center justify-center p-6">
     <div class="max-w-md text-center">
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/public/examples/application/empty-states/1.html
+++ b/public/examples/application/empty-states/1.html
@@ -9,6 +9,7 @@
   <body class="flex min-h-screen items-center justify-center p-6">
     <div class="max-w-md text-center">
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/public/examples/application/empty-states/2-dark.html
+++ b/public/examples/application/empty-states/2-dark.html
@@ -9,6 +9,7 @@
   <body class="flex min-h-screen items-center justify-center p-6">
     <div class="max-w-md text-center">
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/public/examples/application/empty-states/2.html
+++ b/public/examples/application/empty-states/2.html
@@ -9,6 +9,7 @@
   <body class="flex min-h-screen items-center justify-center p-6">
     <div class="max-w-md text-center">
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/public/examples/application/empty-states/3-dark.html
+++ b/public/examples/application/empty-states/3-dark.html
@@ -9,6 +9,7 @@
   <body class="flex min-h-screen items-center justify-center p-6">
     <div class="max-w-md text-center">
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/public/examples/application/empty-states/3.html
+++ b/public/examples/application/empty-states/3.html
@@ -9,6 +9,7 @@
   <body class="flex min-h-screen items-center justify-center p-6">
     <div class="max-w-md text-center">
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/public/examples/application/empty-states/4-dark.html
+++ b/public/examples/application/empty-states/4-dark.html
@@ -9,6 +9,7 @@
   <body class="flex min-h-screen items-center justify-center p-6">
     <div class="max-w-md text-center">
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/public/examples/application/empty-states/4.html
+++ b/public/examples/application/empty-states/4.html
@@ -9,6 +9,7 @@
   <body class="flex min-h-screen items-center justify-center p-6">
     <div class="max-w-md text-center">
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/public/examples/application/empty-states/5-dark.html
+++ b/public/examples/application/empty-states/5-dark.html
@@ -9,6 +9,7 @@
   <body class="flex min-h-screen items-center justify-center p-6">
     <div class="max-w-md text-center">
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/public/examples/application/empty-states/5.html
+++ b/public/examples/application/empty-states/5.html
@@ -9,6 +9,7 @@
   <body class="flex min-h-screen items-center justify-center p-6">
     <div class="max-w-md text-center">
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/public/examples/application/file-uploaders/1-dark.html
+++ b/public/examples/application/file-uploaders/1-dark.html
@@ -15,6 +15,7 @@
         <span class="font-medium dark:text-white"> Upload your file(s) </span>
 
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/file-uploaders/1.html
+++ b/public/examples/application/file-uploaders/1.html
@@ -15,6 +15,7 @@
         <span class="font-medium"> Upload your file(s) </span>
 
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/file-uploaders/2-dark.html
+++ b/public/examples/application/file-uploaders/2-dark.html
@@ -12,6 +12,7 @@
       class="flex flex-col items-center rounded border border-gray-300 bg-white p-4 text-gray-900 shadow-sm sm:p-6 dark:border-gray-700 dark:bg-gray-900 dark:text-white"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/public/examples/application/file-uploaders/2.html
+++ b/public/examples/application/file-uploaders/2.html
@@ -12,6 +12,7 @@
       class="flex flex-col items-center rounded border border-gray-300 p-4 text-gray-900 shadow-sm sm:p-6"
     >
       <svg
+        aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/public/examples/application/filters/1-dark.html
+++ b/public/examples/application/filters/1-dark.html
@@ -16,6 +16,7 @@
 
           <span class="transition-transform group-open:-rotate-180">
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"
@@ -92,6 +93,7 @@
 
           <span class="transition-transform group-open:-rotate-180">
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"

--- a/public/examples/application/filters/1.html
+++ b/public/examples/application/filters/1.html
@@ -16,6 +16,7 @@
 
           <span class="transition-transform group-open:-rotate-180">
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"
@@ -92,6 +93,7 @@
 
           <span class="transition-transform group-open:-rotate-180">
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"

--- a/public/examples/application/filters/2-dark.html
+++ b/public/examples/application/filters/2-dark.html
@@ -18,6 +18,7 @@
 
           <span class="transition-transform group-open:-rotate-180">
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"
@@ -96,6 +97,7 @@
 
           <span class="transition-transform group-open:-rotate-180">
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"

--- a/public/examples/application/filters/2.html
+++ b/public/examples/application/filters/2.html
@@ -16,6 +16,7 @@
 
           <span class="transition-transform group-open:-rotate-180">
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"
@@ -90,6 +91,7 @@
 
           <span class="transition-transform group-open:-rotate-180">
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"

--- a/public/examples/application/inputs/2-dark.html
+++ b/public/examples/application/inputs/2-dark.html
@@ -21,6 +21,7 @@
           class="absolute inset-y-0 right-0 grid w-8 place-content-center text-gray-700 dark:text-gray-200"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"

--- a/public/examples/application/inputs/2.html
+++ b/public/examples/application/inputs/2.html
@@ -19,6 +19,7 @@
 
         <span class="absolute inset-y-0 right-0 grid w-8 place-content-center text-gray-700">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"

--- a/public/examples/application/inputs/3-dark.html
+++ b/public/examples/application/inputs/3-dark.html
@@ -24,6 +24,7 @@
             class="rounded-full p-1.5 text-gray-700 transition-colors hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
           >
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"

--- a/public/examples/application/inputs/3.html
+++ b/public/examples/application/inputs/3.html
@@ -24,6 +24,7 @@
             class="rounded-full p-1.5 text-gray-700 transition-colors hover:bg-gray-100"
           >
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"

--- a/public/examples/application/loaders/1-dark.html
+++ b/public/examples/application/loaders/1-dark.html
@@ -7,26 +7,29 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="flex min-h-screen items-center justify-center p-6">
-    <svg
-      class="mx-auto size-8 animate-spin text-indigo-600 dark:text-indigo-300"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-    >
-      <circle
-        class="opacity-25"
-        cx="12"
-        cy="12"
-        r="10"
-        stroke="currentColor"
-        stroke-width="4"
-      ></circle>
+    <div role="status" aria-label="Loading">
+      <svg
+        class="mx-auto size-8 animate-spin text-indigo-600 dark:text-indigo-300"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <circle
+          class="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          stroke-width="4"
+        ></circle>
 
-      <path
-        class="opacity-75"
-        fill="currentColor"
-        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-      ></path>
-    </svg>
+        <path
+          class="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+        ></path>
+      </svg>
+    </div>
   </body>
 </html>

--- a/public/examples/application/loaders/1.html
+++ b/public/examples/application/loaders/1.html
@@ -7,26 +7,29 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="flex min-h-screen items-center justify-center p-6">
-    <svg
-      class="mx-auto size-8 animate-spin text-indigo-600"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-    >
-      <circle
-        class="opacity-25"
-        cx="12"
-        cy="12"
-        r="10"
-        stroke="currentColor"
-        stroke-width="4"
-      ></circle>
+    <div role="status" aria-label="Loading">
+      <svg
+        class="mx-auto size-8 animate-spin text-indigo-600"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <circle
+          class="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          stroke-width="4"
+        ></circle>
 
-      <path
-        class="opacity-75"
-        fill="currentColor"
-        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-      ></path>
-    </svg>
+        <path
+          class="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+        ></path>
+      </svg>
+    </div>
   </body>
 </html>

--- a/public/examples/application/loaders/2-dark.html
+++ b/public/examples/application/loaders/2-dark.html
@@ -7,12 +7,13 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="flex min-h-screen items-center justify-center p-6">
-    <div class="text-center">
+    <div class="text-center" role="status">
       <svg
         class="mx-auto size-8 animate-spin text-indigo-600 dark:text-indigo-300"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
+        aria-hidden="true"
       >
         <circle
           class="opacity-25"

--- a/public/examples/application/loaders/2.html
+++ b/public/examples/application/loaders/2.html
@@ -7,12 +7,13 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="flex min-h-screen items-center justify-center p-6">
-    <div class="text-center">
+    <div class="text-center" role="status">
       <svg
         class="mx-auto size-8 animate-spin text-indigo-600"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
+        aria-hidden="true"
       >
         <circle
           class="opacity-25"

--- a/public/examples/application/loaders/3-dark.html
+++ b/public/examples/application/loaders/3-dark.html
@@ -7,12 +7,13 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="flex min-h-screen items-center justify-center p-6">
-    <div class="inline-flex items-center gap-3">
+    <div class="inline-flex items-center gap-3" role="status">
       <svg
         class="size-6 animate-spin text-indigo-600 dark:text-indigo-300"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
+        aria-hidden="true"
       >
         <circle
           class="opacity-25"

--- a/public/examples/application/loaders/3.html
+++ b/public/examples/application/loaders/3.html
@@ -7,12 +7,13 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="flex min-h-screen items-center justify-center p-6">
-    <div class="inline-flex items-center gap-3">
+    <div class="inline-flex items-center gap-3" role="status">
       <svg
         class="size-6 animate-spin text-indigo-600"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"
+        aria-hidden="true"
       >
         <circle
           class="opacity-25"

--- a/public/examples/application/loaders/4-dark.html
+++ b/public/examples/application/loaders/4-dark.html
@@ -7,7 +7,7 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="flex min-h-screen items-center justify-center p-6">
-    <div class="w-full max-w-sm">
+    <div class="w-full max-w-sm" role="status">
       <div class="h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
         <div class="h-full w-[80%] animate-pulse bg-indigo-600 dark:bg-indigo-300"></div>
       </div>

--- a/public/examples/application/loaders/4.html
+++ b/public/examples/application/loaders/4.html
@@ -7,7 +7,7 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="flex min-h-screen items-center justify-center p-6">
-    <div class="w-full max-w-sm">
+    <div class="w-full max-w-sm" role="status">
       <div class="h-2 overflow-hidden rounded-full bg-gray-200">
         <div class="h-full w-[80%] animate-pulse bg-indigo-600"></div>
       </div>

--- a/public/examples/application/loaders/5-dark.html
+++ b/public/examples/application/loaders/5-dark.html
@@ -7,13 +7,18 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="flex min-h-screen items-center justify-center p-6">
-    <div class="flex gap-2">
-      <span class="size-3 animate-pulse rounded-full bg-indigo-600 dark:bg-indigo-300"></span>
+    <div class="flex gap-2" role="status" aria-label="Loading">
+      <span
+        class="size-3 animate-pulse rounded-full bg-indigo-600 dark:bg-indigo-300"
+        aria-hidden="true"
+      ></span>
       <span
         class="size-3 animate-pulse rounded-full bg-indigo-600 [animation-delay:0.2s] dark:bg-indigo-300"
+        aria-hidden="true"
       ></span>
       <span
         class="size-3 animate-pulse rounded-full bg-indigo-600 [animation-delay:0.4s] dark:bg-indigo-300"
+        aria-hidden="true"
       ></span>
     </div>
   </body>

--- a/public/examples/application/loaders/5.html
+++ b/public/examples/application/loaders/5.html
@@ -7,10 +7,16 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="flex min-h-screen items-center justify-center p-6">
-    <div class="flex gap-2">
-      <span class="size-3 animate-pulse rounded-full bg-indigo-600"></span>
-      <span class="size-3 animate-pulse rounded-full bg-indigo-600 [animation-delay:0.2s]"></span>
-      <span class="size-3 animate-pulse rounded-full bg-indigo-600 [animation-delay:0.4s]"></span>
+    <div class="flex gap-2" role="status" aria-label="Loading">
+      <span class="size-3 animate-pulse rounded-full bg-indigo-600" aria-hidden="true"></span>
+      <span
+        class="size-3 animate-pulse rounded-full bg-indigo-600 [animation-delay:0.2s]"
+        aria-hidden="true"
+      ></span>
+      <span
+        class="size-3 animate-pulse rounded-full bg-indigo-600 [animation-delay:0.4s]"
+        aria-hidden="true"
+      ></span>
     </div>
   </body>
 </html>

--- a/public/examples/application/loaders/6-dark.html
+++ b/public/examples/application/loaders/6-dark.html
@@ -7,13 +7,18 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="flex min-h-screen items-center justify-center p-6">
-    <div class="flex gap-2">
-      <span class="size-3 animate-ping rounded-full bg-indigo-600 dark:bg-indigo-300"></span>
+    <div class="flex gap-2" role="status" aria-label="Loading">
+      <span
+        class="size-3 animate-ping rounded-full bg-indigo-600 dark:bg-indigo-300"
+        aria-hidden="true"
+      ></span>
       <span
         class="size-3 animate-ping rounded-full bg-indigo-600 [animation-delay:0.2s] dark:bg-indigo-300"
+        aria-hidden="true"
       ></span>
       <span
         class="size-3 animate-ping rounded-full bg-indigo-600 [animation-delay:0.4s] dark:bg-indigo-300"
+        aria-hidden="true"
       ></span>
     </div>
   </body>

--- a/public/examples/application/loaders/6.html
+++ b/public/examples/application/loaders/6.html
@@ -7,10 +7,16 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="flex min-h-screen items-center justify-center p-6">
-    <div class="flex gap-2">
-      <span class="size-3 animate-ping rounded-full bg-indigo-600"></span>
-      <span class="size-3 animate-ping rounded-full bg-indigo-600 [animation-delay:0.2s]"></span>
-      <span class="size-3 animate-ping rounded-full bg-indigo-600 [animation-delay:0.4s]"></span>
+    <div class="flex gap-2" role="status" aria-label="Loading">
+      <span class="size-3 animate-ping rounded-full bg-indigo-600" aria-hidden="true"></span>
+      <span
+        class="size-3 animate-ping rounded-full bg-indigo-600 [animation-delay:0.2s]"
+        aria-hidden="true"
+      ></span>
+      <span
+        class="size-3 animate-ping rounded-full bg-indigo-600 [animation-delay:0.4s]"
+        aria-hidden="true"
+      ></span>
     </div>
   </body>
 </html>

--- a/public/examples/application/loaders/7-dark.html
+++ b/public/examples/application/loaders/7-dark.html
@@ -7,13 +7,18 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="flex min-h-screen items-center justify-center p-6">
-    <div class="flex gap-2">
-      <span class="size-3 animate-bounce rounded-full bg-indigo-600 dark:bg-indigo-300"></span>
+    <div class="flex gap-2" role="status" aria-label="Loading">
+      <span
+        class="size-3 animate-bounce rounded-full bg-indigo-600 dark:bg-indigo-300"
+        aria-hidden="true"
+      ></span>
       <span
         class="size-3 animate-bounce rounded-full bg-indigo-600 [animation-delay:0.2s] dark:bg-indigo-300"
+        aria-hidden="true"
       ></span>
       <span
         class="size-3 animate-bounce rounded-full bg-indigo-600 [animation-delay:0.4s] dark:bg-indigo-300"
+        aria-hidden="true"
       ></span>
     </div>
   </body>

--- a/public/examples/application/loaders/7.html
+++ b/public/examples/application/loaders/7.html
@@ -7,10 +7,16 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="flex min-h-screen items-center justify-center p-6">
-    <div class="flex gap-2">
-      <span class="size-3 animate-bounce rounded-full bg-indigo-600"></span>
-      <span class="size-3 animate-bounce rounded-full bg-indigo-600 [animation-delay:0.2s]"></span>
-      <span class="size-3 animate-bounce rounded-full bg-indigo-600 [animation-delay:0.4s]"></span>
+    <div class="flex gap-2" role="status" aria-label="Loading">
+      <span class="size-3 animate-bounce rounded-full bg-indigo-600" aria-hidden="true"></span>
+      <span
+        class="size-3 animate-bounce rounded-full bg-indigo-600 [animation-delay:0.2s]"
+        aria-hidden="true"
+      ></span>
+      <span
+        class="size-3 animate-bounce rounded-full bg-indigo-600 [animation-delay:0.4s]"
+        aria-hidden="true"
+      ></span>
     </div>
   </body>
 </html>

--- a/public/examples/application/modals/2-dark.html
+++ b/public/examples/application/modals/2-dark.html
@@ -29,10 +29,11 @@
           <button
             type="button"
             data-modal-close
-            class="-me-4 -mt-4 rounded-full p-2 text-gray-400 transition-colors hover:bg-gray-50 hover:text-gray-600 focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 focus:ring-offset-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white focus-visible:outline-none dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-300 dark:focus:ring-indigo-300 dark:focus:ring-offset-gray-900 dark:focus-visible:ring-indigo-300 dark:focus-visible:ring-offset-gray-900"
+            class="-me-4 -mt-4 rounded-full p-2 text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 focus:ring-offset-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white focus-visible:outline-none dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-300 dark:focus:ring-indigo-300 dark:focus:ring-offset-gray-900 dark:focus-visible:ring-indigo-300 dark:focus-visible:ring-offset-gray-900"
             aria-label="Close"
           >
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               class="size-5"
               fill="none"

--- a/public/examples/application/modals/2.html
+++ b/public/examples/application/modals/2.html
@@ -27,10 +27,11 @@
           <button
             type="button"
             data-modal-close
-            class="-me-4 -mt-4 rounded-full p-2 text-gray-400 transition-colors hover:bg-gray-50 hover:text-gray-600 focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 focus:ring-offset-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white focus-visible:outline-none"
+            class="-me-4 -mt-4 rounded-full p-2 text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 focus:ring-offset-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white focus-visible:outline-none"
             aria-label="Close"
           >
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               class="size-5"
               fill="none"

--- a/public/examples/application/modals/4-dark.html
+++ b/public/examples/application/modals/4-dark.html
@@ -29,10 +29,11 @@
           <button
             type="button"
             data-modal-close
-            class="-me-4 -mt-4 rounded-full p-2 text-gray-400 transition-colors hover:bg-gray-50 hover:text-gray-600 focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 focus:ring-offset-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white focus-visible:outline-none dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-300 dark:focus:ring-indigo-300 dark:focus:ring-offset-gray-900 dark:focus-visible:ring-indigo-300 dark:focus-visible:ring-offset-gray-900"
+            class="-me-4 -mt-4 rounded-full p-2 text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 focus:ring-offset-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white focus-visible:outline-none dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-300 dark:focus:ring-indigo-300 dark:focus:ring-offset-gray-900 dark:focus-visible:ring-indigo-300 dark:focus-visible:ring-offset-gray-900"
             aria-label="Close"
           >
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               class="size-5"
               fill="none"

--- a/public/examples/application/modals/4.html
+++ b/public/examples/application/modals/4.html
@@ -27,10 +27,11 @@
           <button
             type="button"
             data-modal-close
-            class="-me-4 -mt-4 rounded-full p-2 text-gray-400 transition-colors hover:bg-gray-50 hover:text-gray-600 focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 focus:ring-offset-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white focus-visible:outline-none"
+            class="-me-4 -mt-4 rounded-full p-2 text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 focus:ring-offset-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white focus-visible:outline-none"
             aria-label="Close"
           >
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               class="size-5"
               fill="none"

--- a/public/examples/application/modals/6-dark.html
+++ b/public/examples/application/modals/6-dark.html
@@ -29,10 +29,11 @@
           <button
             type="button"
             data-modal-close
-            class="-me-4 -mt-4 rounded-full p-2 text-gray-400 transition-colors hover:bg-gray-50 hover:text-gray-600 focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 focus:ring-offset-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white focus-visible:outline-none dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-300 dark:focus:ring-indigo-300 dark:focus:ring-offset-gray-900 dark:focus-visible:ring-indigo-300 dark:focus-visible:ring-offset-gray-900"
+            class="-me-4 -mt-4 rounded-full p-2 text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 focus:ring-offset-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white focus-visible:outline-none dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-300 dark:focus:ring-indigo-300 dark:focus:ring-offset-gray-900 dark:focus-visible:ring-indigo-300 dark:focus-visible:ring-offset-gray-900"
             aria-label="Close"
           >
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               class="size-5"
               fill="none"

--- a/public/examples/application/modals/6.html
+++ b/public/examples/application/modals/6.html
@@ -27,10 +27,11 @@
           <button
             type="button"
             data-modal-close
-            class="-me-4 -mt-4 rounded-full p-2 text-gray-400 transition-colors hover:bg-gray-50 hover:text-gray-600 focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 focus:ring-offset-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white focus-visible:outline-none"
+            class="-me-4 -mt-4 rounded-full p-2 text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 focus:ring-offset-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white focus-visible:outline-none"
             aria-label="Close"
           >
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               class="size-5"
               fill="none"

--- a/public/examples/application/pagination/1-dark.html
+++ b/public/examples/application/pagination/1-dark.html
@@ -7,81 +7,86 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="flex justify-center p-6">
-    <ul class="flex justify-center gap-1 text-gray-900 dark:text-white">
-      <li>
-        <a
-          href="#"
-          class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180 dark:border-gray-700 dark:hover:bg-gray-800"
-          aria-label="Previous page"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="size-4"
-            viewBox="0 0 20 20"
-            fill="currentColor"
+    <nav aria-label="Pagination">
+      <ul class="flex justify-center gap-1 text-gray-900 dark:text-white">
+        <li>
+          <a
+            href="#"
+            class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180 dark:border-gray-700 dark:hover:bg-gray-800"
+            aria-label="Previous page"
           >
-            <path
-              fill-rule="evenodd"
-              d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-              clip-rule="evenodd"
-            />
-          </svg>
-        </a>
-      </li>
+            <svg
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              class="size-4"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </a>
+        </li>
 
-      <li>
-        <a
-          href="#"
-          class="block size-8 rounded border border-gray-200 text-center text-sm/8 font-medium transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
-        >
-          1
-        </a>
-      </li>
-
-      <li
-        class="block size-8 rounded border border-indigo-600 bg-indigo-600 text-center text-sm/8 font-medium text-white"
-      >
-        2
-      </li>
-
-      <li>
-        <a
-          href="#"
-          class="block size-8 rounded border border-gray-200 text-center text-sm/8 font-medium transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
-        >
-          3
-        </a>
-      </li>
-
-      <li>
-        <a
-          href="#"
-          class="block size-8 rounded border border-gray-200 text-center text-sm/8 font-medium transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
-        >
-          4
-        </a>
-      </li>
-
-      <li>
-        <a
-          href="#"
-          class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180 dark:border-gray-700 dark:hover:bg-gray-800"
-          aria-label="Next page"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="size-4"
-            viewBox="0 0 20 20"
-            fill="currentColor"
+        <li>
+          <a
+            href="#"
+            class="block size-8 rounded border border-gray-200 text-center text-sm/8 font-medium transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
           >
-            <path
-              fill-rule="evenodd"
-              d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-              clip-rule="evenodd"
-            />
-          </svg>
-        </a>
-      </li>
-    </ul>
+            1
+          </a>
+        </li>
+
+        <li
+          class="block size-8 rounded border border-indigo-600 bg-indigo-600 text-center text-sm/8 font-medium text-white"
+          aria-current="page"
+        >
+          2
+        </li>
+
+        <li>
+          <a
+            href="#"
+            class="block size-8 rounded border border-gray-200 text-center text-sm/8 font-medium transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
+          >
+            3
+          </a>
+        </li>
+
+        <li>
+          <a
+            href="#"
+            class="block size-8 rounded border border-gray-200 text-center text-sm/8 font-medium transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
+          >
+            4
+          </a>
+        </li>
+
+        <li>
+          <a
+            href="#"
+            class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180 dark:border-gray-700 dark:hover:bg-gray-800"
+            aria-label="Next page"
+          >
+            <svg
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              class="size-4"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </a>
+        </li>
+      </ul>
+    </nav>
   </body>
 </html>

--- a/public/examples/application/pagination/1.html
+++ b/public/examples/application/pagination/1.html
@@ -7,81 +7,86 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="flex justify-center p-6">
-    <ul class="flex justify-center gap-1 text-gray-900">
-      <li>
-        <a
-          href="#"
-          class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180"
-          aria-label="Previous page"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="size-4"
-            viewBox="0 0 20 20"
-            fill="currentColor"
+    <nav aria-label="Pagination">
+      <ul class="flex justify-center gap-1 text-gray-900">
+        <li>
+          <a
+            href="#"
+            class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180"
+            aria-label="Previous page"
           >
-            <path
-              fill-rule="evenodd"
-              d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-              clip-rule="evenodd"
-            />
-          </svg>
-        </a>
-      </li>
+            <svg
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              class="size-4"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </a>
+        </li>
 
-      <li>
-        <a
-          href="#"
-          class="block size-8 rounded border border-gray-200 text-center text-sm/8 font-medium transition-colors hover:bg-gray-50"
-        >
-          1
-        </a>
-      </li>
-
-      <li
-        class="block size-8 rounded border border-indigo-600 bg-indigo-600 text-center text-sm/8 font-medium text-white"
-      >
-        2
-      </li>
-
-      <li>
-        <a
-          href="#"
-          class="block size-8 rounded border border-gray-200 text-center text-sm/8 font-medium transition-colors hover:bg-gray-50"
-        >
-          3
-        </a>
-      </li>
-
-      <li>
-        <a
-          href="#"
-          class="block size-8 rounded border border-gray-200 text-center text-sm/8 font-medium transition-colors hover:bg-gray-50"
-        >
-          4
-        </a>
-      </li>
-
-      <li>
-        <a
-          href="#"
-          class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180"
-          aria-label="Next page"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="size-4"
-            viewBox="0 0 20 20"
-            fill="currentColor"
+        <li>
+          <a
+            href="#"
+            class="block size-8 rounded border border-gray-200 text-center text-sm/8 font-medium transition-colors hover:bg-gray-50"
           >
-            <path
-              fill-rule="evenodd"
-              d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-              clip-rule="evenodd"
-            />
-          </svg>
-        </a>
-      </li>
-    </ul>
+            1
+          </a>
+        </li>
+
+        <li
+          class="block size-8 rounded border border-indigo-600 bg-indigo-600 text-center text-sm/8 font-medium text-white"
+          aria-current="page"
+        >
+          2
+        </li>
+
+        <li>
+          <a
+            href="#"
+            class="block size-8 rounded border border-gray-200 text-center text-sm/8 font-medium transition-colors hover:bg-gray-50"
+          >
+            3
+          </a>
+        </li>
+
+        <li>
+          <a
+            href="#"
+            class="block size-8 rounded border border-gray-200 text-center text-sm/8 font-medium transition-colors hover:bg-gray-50"
+          >
+            4
+          </a>
+        </li>
+
+        <li>
+          <a
+            href="#"
+            class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180"
+            aria-label="Next page"
+          >
+            <svg
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              class="size-4"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </a>
+        </li>
+      </ul>
+    </nav>
   </body>
 </html>

--- a/public/examples/application/pagination/2-dark.html
+++ b/public/examples/application/pagination/2-dark.html
@@ -7,61 +7,65 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="flex justify-center p-6">
-    <ul class="flex justify-center gap-1 text-gray-900 dark:text-white">
-      <li>
-        <a
-          href="#"
-          class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180 dark:border-gray-700 dark:hover:bg-gray-800"
-          aria-label="Previous page"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="size-4"
-            viewBox="0 0 20 20"
-            fill="currentColor"
+    <nav aria-label="Pagination">
+      <ul class="flex justify-center gap-1 text-gray-900 dark:text-white">
+        <li>
+          <a
+            href="#"
+            class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180 dark:border-gray-700 dark:hover:bg-gray-800"
+            aria-label="Previous page"
           >
-            <path
-              fill-rule="evenodd"
-              d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-              clip-rule="evenodd"
+            <svg
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              class="size-4"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </a>
+        </li>
+
+        <li>
+          <label for="Page">
+            <span class="sr-only"> Page </span>
+
+            <input
+              type="number"
+              id="Page"
+              value="2"
+              class="h-8 w-16 rounded border-gray-300 sm:text-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white"
             />
-          </svg>
-        </a>
-      </li>
+          </label>
+        </li>
 
-      <li>
-        <label for="Page">
-          <span class="sr-only"> Page </span>
-
-          <input
-            type="number"
-            id="Page"
-            value="2"
-            class="h-8 w-16 rounded border-gray-300 sm:text-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white"
-          />
-        </label>
-      </li>
-
-      <li>
-        <a
-          href="#"
-          class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180 dark:border-gray-700 dark:hover:bg-gray-800"
-          aria-label="Next page"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="size-4"
-            viewBox="0 0 20 20"
-            fill="currentColor"
+        <li>
+          <a
+            href="#"
+            class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180 dark:border-gray-700 dark:hover:bg-gray-800"
+            aria-label="Next page"
           >
-            <path
-              fill-rule="evenodd"
-              d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-              clip-rule="evenodd"
-            />
-          </svg>
-        </a>
-      </li>
-    </ul>
+            <svg
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              class="size-4"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </a>
+        </li>
+      </ul>
+    </nav>
   </body>
 </html>

--- a/public/examples/application/pagination/2.html
+++ b/public/examples/application/pagination/2.html
@@ -7,61 +7,65 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="flex justify-center p-6">
-    <ul class="flex justify-center gap-1 text-gray-900">
-      <li>
-        <a
-          href="#"
-          class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180"
-          aria-label="Previous page"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="size-4"
-            viewBox="0 0 20 20"
-            fill="currentColor"
+    <nav aria-label="Pagination">
+      <ul class="flex justify-center gap-1 text-gray-900">
+        <li>
+          <a
+            href="#"
+            class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180"
+            aria-label="Previous page"
           >
-            <path
-              fill-rule="evenodd"
-              d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-              clip-rule="evenodd"
+            <svg
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              class="size-4"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </a>
+        </li>
+
+        <li>
+          <label for="Page">
+            <span class="sr-only"> Page </span>
+
+            <input
+              type="number"
+              id="Page"
+              value="2"
+              class="h-8 w-16 rounded border-gray-300 sm:text-sm"
             />
-          </svg>
-        </a>
-      </li>
+          </label>
+        </li>
 
-      <li>
-        <label for="Page">
-          <span class="sr-only"> Page </span>
-
-          <input
-            type="number"
-            id="Page"
-            value="2"
-            class="h-8 w-16 rounded border-gray-300 sm:text-sm"
-          />
-        </label>
-      </li>
-
-      <li>
-        <a
-          href="#"
-          class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180"
-          aria-label="Next page"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="size-4"
-            viewBox="0 0 20 20"
-            fill="currentColor"
+        <li>
+          <a
+            href="#"
+            class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180"
+            aria-label="Next page"
           >
-            <path
-              fill-rule="evenodd"
-              d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-              clip-rule="evenodd"
-            />
-          </svg>
-        </a>
-      </li>
-    </ul>
+            <svg
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              class="size-4"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </a>
+        </li>
+      </ul>
+    </nav>
   </body>
 </html>

--- a/public/examples/application/pagination/3-dark.html
+++ b/public/examples/application/pagination/3-dark.html
@@ -7,50 +7,54 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="flex justify-center p-6">
-    <ul class="flex justify-center gap-3 text-gray-900 dark:text-white">
-      <li>
-        <a
-          href="#"
-          class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180 dark:border-gray-700 dark:hover:bg-gray-800"
-          aria-label="Previous page"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="size-4"
-            viewBox="0 0 20 20"
-            fill="currentColor"
+    <nav aria-label="Pagination">
+      <ul class="flex justify-center gap-3 text-gray-900 dark:text-white">
+        <li>
+          <a
+            href="#"
+            class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180 dark:border-gray-700 dark:hover:bg-gray-800"
+            aria-label="Previous page"
           >
-            <path
-              fill-rule="evenodd"
-              d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-              clip-rule="evenodd"
-            />
-          </svg>
-        </a>
-      </li>
+            <svg
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              class="size-4"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </a>
+        </li>
 
-      <li class="text-sm/8 font-medium tracking-widest">2/12</li>
+        <li class="text-sm/8 font-medium tracking-widest">2/12</li>
 
-      <li>
-        <a
-          href="#"
-          class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180 dark:border-gray-700 dark:hover:bg-gray-800"
-          aria-label="Next page"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="size-4"
-            viewBox="0 0 20 20"
-            fill="currentColor"
+        <li>
+          <a
+            href="#"
+            class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180 dark:border-gray-700 dark:hover:bg-gray-800"
+            aria-label="Next page"
           >
-            <path
-              fill-rule="evenodd"
-              d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-              clip-rule="evenodd"
-            />
-          </svg>
-        </a>
-      </li>
-    </ul>
+            <svg
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              class="size-4"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </a>
+        </li>
+      </ul>
+    </nav>
   </body>
 </html>

--- a/public/examples/application/pagination/3.html
+++ b/public/examples/application/pagination/3.html
@@ -7,50 +7,54 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="flex justify-center p-6">
-    <ul class="flex justify-center gap-3 text-gray-900">
-      <li>
-        <a
-          href="#"
-          class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180"
-          aria-label="Previous page"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="size-4"
-            viewBox="0 0 20 20"
-            fill="currentColor"
+    <nav aria-label="Pagination">
+      <ul class="flex justify-center gap-3 text-gray-900">
+        <li>
+          <a
+            href="#"
+            class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180"
+            aria-label="Previous page"
           >
-            <path
-              fill-rule="evenodd"
-              d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-              clip-rule="evenodd"
-            />
-          </svg>
-        </a>
-      </li>
+            <svg
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              class="size-4"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </a>
+        </li>
 
-      <li class="text-sm/8 font-medium tracking-widest">2/12</li>
+        <li class="text-sm/8 font-medium tracking-widest">2/12</li>
 
-      <li>
-        <a
-          href="#"
-          class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180"
-          aria-label="Next page"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="size-4"
-            viewBox="0 0 20 20"
-            fill="currentColor"
+        <li>
+          <a
+            href="#"
+            class="grid size-8 place-content-center rounded border border-gray-200 transition-colors hover:bg-gray-50 rtl:rotate-180"
+            aria-label="Next page"
           >
-            <path
-              fill-rule="evenodd"
-              d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-              clip-rule="evenodd"
-            />
-          </svg>
-        </a>
-      </li>
-    </ul>
+            <svg
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              class="size-4"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </a>
+        </li>
+      </ul>
+    </nav>
   </body>
 </html>

--- a/public/examples/application/progress-bars/1.html
+++ b/public/examples/application/progress-bars/1.html
@@ -7,7 +7,13 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="mx-auto max-w-md p-6">
-    <div role="progressbar" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">
+    <div
+      role="progressbar"
+      aria-valuenow="25"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-label="Progress"
+    >
       <p class="text-sm font-medium text-gray-900">25%</p>
 
       <div class="mt-2 h-2 w-full rounded-full bg-gray-200">

--- a/public/examples/application/progress-bars/2.html
+++ b/public/examples/application/progress-bars/2.html
@@ -7,9 +7,15 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="mx-auto max-w-md space-y-6 p-6">
-    <div role="progressbar" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">
+    <div
+      role="progressbar"
+      aria-valuenow="25"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-labelledby="UpdatingLabel"
+    >
       <div class="flex justify-between gap-4">
-        <span class="text-sm font-medium text-gray-900">Updating</span>
+        <span id="UpdatingLabel" class="text-sm font-medium text-gray-900">Updating</span>
 
         <span class="text-sm font-medium text-gray-900">25%</span>
       </div>
@@ -19,9 +25,15 @@
       </div>
     </div>
 
-    <div role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">
+    <div
+      role="progressbar"
+      aria-valuenow="100"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-labelledby="DownloadingLabel"
+    >
       <div class="flex justify-between gap-4">
-        <span class="text-sm font-medium text-gray-900">Downloading</span>
+        <span id="DownloadingLabel" class="text-sm font-medium text-gray-900">Downloading</span>
 
         <span class="text-sm font-medium text-gray-900">100%</span>
       </div>
@@ -31,9 +43,15 @@
       </div>
     </div>
 
-    <div role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100">
+    <div
+      role="progressbar"
+      aria-valuenow="50"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-labelledby="LoadingLabel"
+    >
       <div class="flex justify-between gap-4">
-        <span class="text-sm font-medium text-gray-900">Loading</span>
+        <span id="LoadingLabel" class="text-sm font-medium text-gray-900">Loading</span>
 
         <span class="text-sm font-medium text-gray-900">50%</span>
       </div>

--- a/public/examples/application/progress-bars/3.html
+++ b/public/examples/application/progress-bars/3.html
@@ -7,8 +7,16 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="mx-auto max-w-md space-y-6 p-6">
-    <div role="progressbar" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">
-      <p class="text-xs font-medium tracking-wide text-gray-700 uppercase">Download</p>
+    <div
+      role="progressbar"
+      aria-valuenow="25"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-labelledby="DownloadLabel"
+    >
+      <p id="DownloadLabel" class="text-xs font-medium tracking-wide text-gray-700 uppercase">
+        Download
+      </p>
 
       <div class="mt-2 h-1 w-full bg-gray-200">
         <div class="h-full bg-blue-600" style="width: 25%"></div>
@@ -17,8 +25,16 @@
       <p class="mt-2 text-xs text-gray-700">1.2 of 3.8 MB</p>
     </div>
 
-    <div role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100">
-      <p class="text-xs font-medium tracking-wide text-gray-700 uppercase">File Conversion</p>
+    <div
+      role="progressbar"
+      aria-valuenow="75"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-labelledby="FileConversionLabel"
+    >
+      <p id="FileConversionLabel" class="text-xs font-medium tracking-wide text-gray-700 uppercase">
+        File Conversion
+      </p>
 
       <div class="mt-2 h-1 w-full bg-gray-200">
         <div class="h-full bg-blue-600" style="width: 75%"></div>
@@ -27,8 +43,16 @@
       <p class="mt-2 text-xs text-gray-700">3/4 files done</p>
     </div>
 
-    <div role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">
-      <p class="text-xs font-medium tracking-wide text-gray-700 uppercase">File Sync</p>
+    <div
+      role="progressbar"
+      aria-valuenow="100"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-labelledby="FileSyncLabel"
+    >
+      <p id="FileSyncLabel" class="text-xs font-medium tracking-wide text-gray-700 uppercase">
+        File Sync
+      </p>
 
       <div class="mt-2 h-1 w-full bg-gray-200">
         <div class="h-full bg-green-600" style="width: 100%"></div>

--- a/public/examples/application/progress-bars/4.html
+++ b/public/examples/application/progress-bars/4.html
@@ -14,8 +14,9 @@
         aria-valuenow="25"
         aria-valuemin="0"
         aria-valuemax="100"
+        aria-labelledby="LoadingCircleLabel"
       >
-        <svg class="size-full" viewBox="0 0 100 100">
+        <svg class="size-full" viewBox="0 0 100 100" aria-hidden="true">
           <circle
             cx="50"
             cy="50"
@@ -45,7 +46,7 @@
         </div>
       </div>
 
-      <p class="mt-2 text-sm text-gray-700">Loading</p>
+      <p id="LoadingCircleLabel" class="mt-2 text-sm text-gray-700">Loading</p>
     </div>
 
     <div class="text-center">
@@ -55,8 +56,9 @@
         aria-valuenow="75"
         aria-valuemin="0"
         aria-valuemax="100"
+        aria-labelledby="NearlyDoneCircleLabel"
       >
-        <svg class="size-full" viewBox="0 0 100 100">
+        <svg class="size-full" viewBox="0 0 100 100" aria-hidden="true">
           <circle
             cx="50"
             cy="50"
@@ -86,7 +88,7 @@
         </div>
       </div>
 
-      <p class="mt-2 text-sm text-gray-700">Nearly done</p>
+      <p id="NearlyDoneCircleLabel" class="mt-2 text-sm text-gray-700">Nearly done</p>
     </div>
   </body>
 </html>

--- a/public/examples/application/selects/3-dark.html
+++ b/public/examples/application/selects/3-dark.html
@@ -23,6 +23,7 @@
           class="absolute inset-y-0 right-0 grid w-8 place-content-center text-gray-700 dark:text-gray-200"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"

--- a/public/examples/application/selects/3.html
+++ b/public/examples/application/selects/3.html
@@ -21,6 +21,7 @@
 
         <span class="absolute inset-y-0 right-0 grid w-8 place-content-center text-gray-700">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"

--- a/public/examples/application/side-menu/1-dark.html
+++ b/public/examples/application/side-menu/1-dark.html
@@ -36,6 +36,7 @@
 
                 <span class="shrink-0 transition duration-300 group-open:-rotate-180">
                   <svg
+                    aria-hidden="true"
                     xmlns="http://www.w3.org/2000/svg"
                     class="size-5"
                     viewBox="0 0 20 20"
@@ -99,6 +100,7 @@
 
                 <span class="shrink-0 transition duration-300 group-open:-rotate-180">
                   <svg
+                    aria-hidden="true"
                     xmlns="http://www.w3.org/2000/svg"
                     class="size-5"
                     viewBox="0 0 20 20"

--- a/public/examples/application/side-menu/1.html
+++ b/public/examples/application/side-menu/1.html
@@ -34,6 +34,7 @@
 
                 <span class="shrink-0 transition duration-300 group-open:-rotate-180">
                   <svg
+                    aria-hidden="true"
                     xmlns="http://www.w3.org/2000/svg"
                     class="size-5"
                     viewBox="0 0 20 20"
@@ -97,6 +98,7 @@
 
                 <span class="shrink-0 transition duration-300 group-open:-rotate-180">
                   <svg
+                    aria-hidden="true"
                     xmlns="http://www.w3.org/2000/svg"
                     class="size-5"
                     viewBox="0 0 20 20"

--- a/public/examples/application/side-menu/2-dark.html
+++ b/public/examples/application/side-menu/2-dark.html
@@ -24,8 +24,10 @@
             <a
               href="#"
               class="group relative grid place-content-center rounded-lg bg-gray-100 px-4 py-2 text-gray-900 dark:bg-gray-800 dark:text-white"
+              aria-label="General"
             >
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5"
                 fill="none"
@@ -57,8 +59,10 @@
             <a
               href="#"
               class="group relative grid place-content-center rounded-lg px-4 py-2 text-gray-700 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white"
+              aria-label="Teams"
             >
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5"
                 fill="none"
@@ -85,8 +89,10 @@
             <a
               href="#"
               class="group relative grid place-content-center rounded-lg px-4 py-2 text-gray-700 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white"
+              aria-label="Billing"
             >
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5"
                 fill="none"
@@ -113,8 +119,10 @@
             <a
               href="#"
               class="group relative grid place-content-center rounded-lg px-4 py-2 text-gray-700 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white"
+              aria-label="Invoices"
             >
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5"
                 fill="none"
@@ -141,8 +149,10 @@
             <a
               href="#"
               class="group relative grid place-content-center rounded-lg px-4 py-2 text-gray-700 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white"
+              aria-label="Account"
             >
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5"
                 fill="none"
@@ -173,8 +183,10 @@
         <a
           href="#"
           class="group relative grid place-content-center rounded-lg px-4 py-2 text-gray-700 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white"
+          aria-label="Logout"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5"
             fill="none"

--- a/public/examples/application/side-menu/2.html
+++ b/public/examples/application/side-menu/2.html
@@ -22,8 +22,10 @@
             <a
               href="#"
               class="group relative grid place-content-center rounded-lg bg-gray-100 px-4 py-2 text-gray-900"
+              aria-label="General"
             >
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5"
                 fill="none"
@@ -55,8 +57,10 @@
             <a
               href="#"
               class="group relative grid place-content-center rounded-lg px-4 py-2 text-gray-700 transition-colors hover:bg-gray-100 hover:text-gray-900"
+              aria-label="Teams"
             >
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5"
                 fill="none"
@@ -83,8 +87,10 @@
             <a
               href="#"
               class="group relative grid place-content-center rounded-lg px-4 py-2 text-gray-700 transition-colors hover:bg-gray-100 hover:text-gray-900"
+              aria-label="Billing"
             >
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5"
                 fill="none"
@@ -111,8 +117,10 @@
             <a
               href="#"
               class="group relative grid place-content-center rounded-lg px-4 py-2 text-gray-700 transition-colors hover:bg-gray-100 hover:text-gray-900"
+              aria-label="Invoices"
             >
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5"
                 fill="none"
@@ -139,8 +147,10 @@
             <a
               href="#"
               class="group relative grid place-content-center rounded-lg px-4 py-2 text-gray-700 transition-colors hover:bg-gray-100 hover:text-gray-900"
+              aria-label="Account"
             >
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5"
                 fill="none"
@@ -169,8 +179,10 @@
         <a
           href="#"
           class="group relative grid place-content-center rounded-lg px-4 py-2 text-gray-700 transition-colors hover:bg-gray-100 hover:text-gray-900"
+          aria-label="Logout"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5"
             fill="none"

--- a/public/examples/application/stats/1-dark.html
+++ b/public/examples/application/stats/1-dark.html
@@ -14,6 +14,7 @@
         class="inline-flex gap-2 self-end rounded-sm bg-green-100 p-1 text-green-600 dark:bg-green-700 dark:text-green-50"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
           fill="none"
@@ -27,6 +28,8 @@
             d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
           />
         </svg>
+
+        <span class="sr-only">Increase: </span>
 
         <span class="text-xs font-medium"> 67.81% </span>
       </div>
@@ -49,6 +52,7 @@
         class="inline-flex gap-2 self-end rounded-sm bg-red-100 p-1 text-red-600 dark:bg-red-700 dark:text-red-50"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
           fill="none"
@@ -62,6 +66,8 @@
             d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6"
           />
         </svg>
+
+        <span class="sr-only">Decrease: </span>
 
         <span class="text-xs font-medium"> 67.81% </span>
       </div>

--- a/public/examples/application/stats/1.html
+++ b/public/examples/application/stats/1.html
@@ -10,6 +10,7 @@
     <article class="flex flex-col gap-4 rounded-lg border border-gray-100 bg-white p-6">
       <div class="inline-flex gap-2 self-end rounded-sm bg-green-100 p-1 text-green-600">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
           fill="none"
@@ -23,6 +24,8 @@
             d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
           />
         </svg>
+
+        <span class="sr-only">Increase: </span>
 
         <span class="text-xs font-medium"> 67.81% </span>
       </div>
@@ -41,6 +44,7 @@
     <article class="flex flex-col gap-4 rounded-lg border border-gray-100 bg-white p-6">
       <div class="inline-flex gap-2 self-end rounded-sm bg-red-100 p-1 text-red-600">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
           fill="none"
@@ -54,6 +58,8 @@
             d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6"
           />
         </svg>
+
+        <span class="sr-only">Decrease: </span>
 
         <span class="text-xs font-medium"> 67.81% </span>
       </div>

--- a/public/examples/application/stats/2-dark.html
+++ b/public/examples/application/stats/2-dark.html
@@ -15,6 +15,7 @@
           class="hidden rounded-full bg-gray-100 p-2 text-gray-600 sm:block dark:bg-gray-800 dark:text-gray-300"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-6"
             fill="none"
@@ -41,6 +42,7 @@
         class="inline-flex gap-2 rounded-sm bg-green-100 p-1 text-green-600 dark:bg-green-700 dark:text-green-50"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
           fill="none"
@@ -55,6 +57,8 @@
           />
         </svg>
 
+        <span class="sr-only">Increase: </span>
+
         <span class="text-xs font-medium"> 67.81% </span>
       </div>
     </article>
@@ -67,6 +71,7 @@
           class="hidden rounded-full bg-gray-100 p-2 text-gray-600 sm:block dark:bg-gray-800 dark:text-gray-300"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-6"
             fill="none"
@@ -93,6 +98,7 @@
         class="inline-flex gap-2 rounded-sm bg-red-100 p-1 text-red-600 dark:bg-red-700 dark:text-red-50"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
           fill="none"
@@ -106,6 +112,8 @@
             d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6"
           />
         </svg>
+
+        <span class="sr-only">Decrease: </span>
 
         <span class="text-xs font-medium"> 67.81% </span>
       </div>

--- a/public/examples/application/stats/2.html
+++ b/public/examples/application/stats/2.html
@@ -11,6 +11,7 @@
       <div class="flex items-center gap-4">
         <span class="hidden rounded-full bg-gray-100 p-2 text-gray-600 sm:block">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-6"
             fill="none"
@@ -35,6 +36,7 @@
 
       <div class="inline-flex gap-2 rounded-sm bg-green-100 p-1 text-green-600">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
           fill="none"
@@ -49,6 +51,8 @@
           />
         </svg>
 
+        <span class="sr-only">Increase: </span>
+
         <span class="text-xs font-medium"> 67.81% </span>
       </div>
     </article>
@@ -57,6 +61,7 @@
       <div class="flex items-center gap-4">
         <span class="hidden rounded-full bg-gray-100 p-2 text-gray-600 sm:block">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-6"
             fill="none"
@@ -81,6 +86,7 @@
 
       <div class="inline-flex gap-2 rounded-sm bg-red-100 p-1 text-red-600">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
           fill="none"
@@ -94,6 +100,8 @@
             d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6"
           />
         </svg>
+
+        <span class="sr-only">Decrease: </span>
 
         <span class="text-xs font-medium"> 67.81% </span>
       </div>

--- a/public/examples/application/stats/3-dark.html
+++ b/public/examples/application/stats/3-dark.html
@@ -20,6 +20,7 @@
         class="inline-flex gap-2 rounded-sm bg-green-100 p-1 text-green-600 dark:bg-green-700 dark:text-green-50"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
           fill="none"
@@ -33,6 +34,8 @@
             d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
           />
         </svg>
+
+        <span class="sr-only">Increase: </span>
 
         <span class="text-xs font-medium"> 67.81% </span>
       </div>
@@ -51,6 +54,7 @@
         class="inline-flex gap-2 rounded-sm bg-red-100 p-1 text-red-600 dark:bg-red-700 dark:text-red-50"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
           fill="none"
@@ -64,6 +68,8 @@
             d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6"
           />
         </svg>
+
+        <span class="sr-only">Decrease: </span>
 
         <span class="text-xs font-medium"> 67.81% </span>
       </div>

--- a/public/examples/application/stats/3.html
+++ b/public/examples/application/stats/3.html
@@ -16,6 +16,7 @@
 
       <div class="inline-flex gap-2 rounded-sm bg-green-100 p-1 text-green-600">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
           fill="none"
@@ -30,6 +31,8 @@
           />
         </svg>
 
+        <span class="sr-only">Increase: </span>
+
         <span class="text-xs font-medium"> 67.81% </span>
       </div>
     </article>
@@ -43,6 +46,7 @@
 
       <div class="inline-flex gap-2 rounded-sm bg-red-100 p-1 text-red-600">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
           fill="none"
@@ -56,6 +60,8 @@
             d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6"
           />
         </svg>
+
+        <span class="sr-only">Decrease: </span>
 
         <span class="text-xs font-medium"> 67.81% </span>
       </div>

--- a/public/examples/application/stats/4-dark.html
+++ b/public/examples/application/stats/4-dark.html
@@ -14,6 +14,7 @@
         class="rounded-full bg-blue-100 p-3 text-blue-600 dark:bg-blue-500/20 dark:text-blue-400"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-8"
           fill="none"
@@ -43,6 +44,7 @@
         class="rounded-full bg-blue-100 p-3 text-blue-600 sm:order-last dark:bg-blue-500/20 dark:text-blue-400"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-8"
           fill="none"

--- a/public/examples/application/stats/4.html
+++ b/public/examples/application/stats/4.html
@@ -10,6 +10,7 @@
     <article class="flex items-center gap-4 rounded-lg border border-gray-100 bg-white p-6">
       <span class="rounded-full bg-blue-100 p-3 text-blue-600">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-8"
           fill="none"
@@ -37,6 +38,7 @@
     >
       <span class="rounded-full bg-blue-100 p-3 text-blue-600 sm:order-last">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-8"
           fill="none"

--- a/public/examples/application/stats/5-dark.html
+++ b/public/examples/application/stats/5-dark.html
@@ -18,6 +18,7 @@
 
       <div class="mt-1 flex gap-1 text-green-600">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
           fill="none"
@@ -31,6 +32,8 @@
             d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
           />
         </svg>
+
+        <span class="sr-only">Increase: </span>
 
         <p class="flex gap-2 text-xs">
           <span class="font-medium"> 67.81% </span>
@@ -51,6 +54,7 @@
 
       <div class="mt-1 flex gap-1 text-red-600">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
           fill="none"
@@ -64,6 +68,8 @@
             d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6"
           />
         </svg>
+
+        <span class="sr-only">Decrease: </span>
 
         <p class="flex gap-2 text-xs">
           <span class="font-medium"> 67.81% </span>

--- a/public/examples/application/stats/5.html
+++ b/public/examples/application/stats/5.html
@@ -16,6 +16,7 @@
 
       <div class="mt-1 flex gap-1 text-green-600">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
           fill="none"
@@ -29,6 +30,8 @@
             d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
           />
         </svg>
+
+        <span class="sr-only">Increase: </span>
 
         <p class="flex gap-2 text-xs">
           <span class="font-medium"> 67.81% </span>
@@ -47,6 +50,7 @@
 
       <div class="mt-1 flex gap-1 text-red-600">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
           fill="none"
@@ -60,6 +64,8 @@
             d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6"
           />
         </svg>
+
+        <span class="sr-only">Decrease: </span>
 
         <p class="flex gap-2 text-xs">
           <span class="font-medium"> 67.81% </span>

--- a/public/examples/application/stats/6-dark.html
+++ b/public/examples/application/stats/6-dark.html
@@ -21,6 +21,7 @@
           class="rounded-full bg-blue-100 p-3 text-blue-600 dark:bg-blue-500/20 dark:text-blue-400"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-8"
             fill="none"
@@ -39,6 +40,7 @@
 
       <div class="mt-1 flex gap-1 text-green-600">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
           fill="none"
@@ -52,6 +54,8 @@
             d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
           />
         </svg>
+
+        <span class="sr-only">Increase: </span>
 
         <p class="flex gap-2 text-xs">
           <span class="font-medium"> 67.81% </span>
@@ -75,6 +79,7 @@
           class="rounded-full bg-blue-100 p-3 text-blue-600 dark:bg-blue-500/20 dark:text-blue-400"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-8"
             fill="none"
@@ -93,6 +98,7 @@
 
       <div class="mt-1 flex gap-1 text-red-600">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
           fill="none"
@@ -106,6 +112,8 @@
             d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6"
           />
         </svg>
+
+        <span class="sr-only">Decrease: </span>
 
         <p class="flex gap-2 text-xs">
           <span class="font-medium"> 67.81% </span>

--- a/public/examples/application/stats/6.html
+++ b/public/examples/application/stats/6.html
@@ -17,6 +17,7 @@
 
         <span class="rounded-full bg-blue-100 p-3 text-blue-600">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-8"
             fill="none"
@@ -35,6 +36,7 @@
 
       <div class="mt-1 flex gap-1 text-green-600">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
           fill="none"
@@ -48,6 +50,8 @@
             d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
           />
         </svg>
+
+        <span class="sr-only">Increase: </span>
 
         <p class="flex gap-2 text-xs">
           <span class="font-medium"> 67.81% </span>
@@ -67,6 +71,7 @@
 
         <span class="rounded-full bg-blue-100 p-3 text-blue-600">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-8"
             fill="none"
@@ -85,6 +90,7 @@
 
       <div class="mt-1 flex gap-1 text-red-600">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           class="size-4"
           fill="none"
@@ -98,6 +104,8 @@
             d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6"
           />
         </svg>
+
+        <span class="sr-only">Decrease: </span>
 
         <p class="flex gap-2 text-xs">
           <span class="font-medium"> 67.81% </span>

--- a/public/examples/application/steps/1-dark.html
+++ b/public/examples/application/steps/1-dark.html
@@ -17,9 +17,10 @@
 
         <ol class="mt-4 grid grid-cols-3 text-sm font-medium text-gray-600 dark:text-gray-300">
           <li class="flex items-center justify-start text-blue-500 sm:gap-1.5">
-            <span class="hidden sm:inline"> Details </span>
+            <span class="sr-only sm:not-sr-only sm:inline"> Details </span>
 
             <svg
+              aria-hidden="true"
               class="size-6 sm:size-5"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
@@ -36,9 +37,10 @@
           </li>
 
           <li class="flex items-center justify-center text-blue-500 sm:gap-1.5">
-            <span class="hidden sm:inline"> Address </span>
+            <span class="sr-only sm:not-sr-only sm:inline"> Address </span>
 
             <svg
+              aria-hidden="true"
               class="size-6 sm:size-5"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
@@ -60,9 +62,10 @@
           </li>
 
           <li class="flex items-center justify-end sm:gap-1.5">
-            <span class="hidden sm:inline"> Payment </span>
+            <span class="sr-only sm:not-sr-only sm:inline"> Payment </span>
 
             <svg
+              aria-hidden="true"
               class="size-6 sm:size-5"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"

--- a/public/examples/application/steps/1.html
+++ b/public/examples/application/steps/1.html
@@ -17,9 +17,10 @@
 
         <ol class="mt-4 grid grid-cols-3 text-sm font-medium text-gray-600">
           <li class="flex items-center justify-start text-blue-500 sm:gap-1.5">
-            <span class="hidden sm:inline"> Details </span>
+            <span class="sr-only sm:not-sr-only sm:inline"> Details </span>
 
             <svg
+              aria-hidden="true"
               class="size-6 sm:size-5"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
@@ -36,9 +37,10 @@
           </li>
 
           <li class="flex items-center justify-center text-blue-500 sm:gap-1.5">
-            <span class="hidden sm:inline"> Address </span>
+            <span class="sr-only sm:not-sr-only sm:inline"> Address </span>
 
             <svg
+              aria-hidden="true"
               class="size-6 sm:size-5"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
@@ -60,9 +62,10 @@
           </li>
 
           <li class="flex items-center justify-end sm:gap-1.5">
-            <span class="hidden sm:inline"> Payment </span>
+            <span class="sr-only sm:not-sr-only sm:inline"> Payment </span>
 
             <svg
+              aria-hidden="true"
               class="size-6 sm:size-5"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"

--- a/public/examples/application/steps/3-dark.html
+++ b/public/examples/application/steps/3-dark.html
@@ -19,6 +19,7 @@
               class="absolute start-0 -bottom-7 rounded-full bg-blue-500 text-white dark:text-gray-900"
             >
               <svg
+                aria-hidden="true"
                 class="size-5"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 20 20"
@@ -32,9 +33,10 @@
               </svg>
             </span>
 
-            <span class="hidden sm:block"> Details </span>
+            <span class="sr-only sm:not-sr-only sm:block"> Details </span>
 
             <svg
+              aria-hidden="true"
               class="size-6 sm:hidden"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
@@ -55,6 +57,7 @@
               class="absolute -bottom-7 left-1/2 -translate-x-1/2 rounded-full bg-blue-500 text-white dark:text-gray-900"
             >
               <svg
+                aria-hidden="true"
                 class="size-5"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 20 20"
@@ -68,9 +71,10 @@
               </svg>
             </span>
 
-            <span class="hidden sm:block"> Address </span>
+            <span class="sr-only sm:not-sr-only sm:block"> Address </span>
 
             <svg
+              aria-hidden="true"
               class="mx-auto size-6 sm:hidden"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
@@ -96,6 +100,7 @@
               class="absolute end-0 -bottom-7 rounded-full bg-gray-500 text-white dark:bg-gray-400 dark:text-gray-900"
             >
               <svg
+                aria-hidden="true"
                 class="size-5"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 20 20"
@@ -109,9 +114,10 @@
               </svg>
             </span>
 
-            <span class="hidden sm:block"> Payment </span>
+            <span class="sr-only sm:not-sr-only sm:block"> Payment </span>
 
             <svg
+              aria-hidden="true"
               class="size-6 sm:hidden"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"

--- a/public/examples/application/steps/3.html
+++ b/public/examples/application/steps/3.html
@@ -15,6 +15,7 @@
           <li class="relative flex justify-start text-blue-500">
             <span class="absolute start-0 -bottom-7 rounded-full bg-blue-500 text-white">
               <svg
+                aria-hidden="true"
                 class="size-5"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 20 20"
@@ -28,9 +29,10 @@
               </svg>
             </span>
 
-            <span class="hidden sm:block"> Details </span>
+            <span class="sr-only sm:not-sr-only sm:block"> Details </span>
 
             <svg
+              aria-hidden="true"
               class="size-6 sm:hidden"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
@@ -51,6 +53,7 @@
               class="absolute -bottom-7 left-1/2 -translate-x-1/2 rounded-full bg-blue-500 text-white"
             >
               <svg
+                aria-hidden="true"
                 class="size-5"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 20 20"
@@ -64,9 +67,10 @@
               </svg>
             </span>
 
-            <span class="hidden sm:block"> Address </span>
+            <span class="sr-only sm:not-sr-only sm:block"> Address </span>
 
             <svg
+              aria-hidden="true"
               class="mx-auto size-6 sm:hidden"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
@@ -90,6 +94,7 @@
           <li class="relative flex justify-end">
             <span class="absolute end-0 -bottom-7 rounded-full bg-gray-500 text-white">
               <svg
+                aria-hidden="true"
                 class="size-5"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 20 20"
@@ -103,9 +108,10 @@
               </svg>
             </span>
 
-            <span class="hidden sm:block"> Payment </span>
+            <span class="sr-only sm:not-sr-only sm:block"> Payment </span>
 
             <svg
+              aria-hidden="true"
               class="size-6 sm:hidden"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"

--- a/public/examples/application/steps/4-dark.html
+++ b/public/examples/application/steps/4-dark.html
@@ -16,6 +16,7 @@
         >
           <li class="flex items-center justify-center gap-2 p-4">
             <svg
+              aria-hidden="true"
               class="size-7 shrink-0"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
@@ -51,6 +52,7 @@
             </span>
 
             <svg
+              aria-hidden="true"
               class="size-7 shrink-0"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
@@ -79,6 +81,7 @@
 
           <li class="flex items-center justify-center gap-2 p-4">
             <svg
+              aria-hidden="true"
               class="size-7 shrink-0"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"

--- a/public/examples/application/steps/4.html
+++ b/public/examples/application/steps/4.html
@@ -16,6 +16,7 @@
         >
           <li class="flex items-center justify-center gap-2 p-4">
             <svg
+              aria-hidden="true"
               class="size-7 shrink-0"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
@@ -49,6 +50,7 @@
             </span>
 
             <svg
+              aria-hidden="true"
               class="size-7 shrink-0"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
@@ -77,6 +79,7 @@
 
           <li class="flex items-center justify-center gap-2 p-4">
             <svg
+              aria-hidden="true"
               class="size-7 shrink-0"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"

--- a/public/examples/application/tabs/2-dark.html
+++ b/public/examples/application/tabs/2-dark.html
@@ -15,6 +15,7 @@
           class="flex items-center gap-2 border-b-2 border-blue-600 px-4 py-2 text-sm font-medium text-blue-600 transition-colors hover:text-blue-700 dark:hover:text-blue-500"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
@@ -38,6 +39,7 @@
           class="flex items-center gap-2 border-b-2 border-transparent px-4 py-2 text-sm font-medium text-gray-600 transition-colors hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-200"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
@@ -66,6 +68,7 @@
           class="flex items-center gap-2 border-b-2 border-transparent px-4 py-2 text-sm font-medium text-gray-600 transition-colors hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-200"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"

--- a/public/examples/application/tabs/2.html
+++ b/public/examples/application/tabs/2.html
@@ -15,6 +15,7 @@
           class="flex items-center gap-2 border-b-2 border-blue-600 px-4 py-2 text-sm font-medium text-blue-600 transition-colors hover:text-blue-700"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
@@ -38,6 +39,7 @@
           class="flex items-center gap-2 border-b-2 border-transparent px-4 py-2 text-sm font-medium text-gray-600 transition-colors hover:text-gray-700"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
@@ -66,6 +68,7 @@
           class="flex items-center gap-2 border-b-2 border-transparent px-4 py-2 text-sm font-medium text-gray-600 transition-colors hover:text-gray-700"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"

--- a/public/examples/application/toasts/1-dark.html
+++ b/public/examples/application/toasts/1-dark.html
@@ -13,6 +13,7 @@
     >
       <div class="flex items-start gap-4">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/toasts/1.html
+++ b/public/examples/application/toasts/1.html
@@ -10,6 +10,7 @@
     <div role="alert" class="rounded-md border border-green-500 bg-green-50 p-4 shadow-sm">
       <div class="flex items-start gap-4">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/toasts/2-dark.html
+++ b/public/examples/application/toasts/2-dark.html
@@ -13,6 +13,7 @@
     >
       <div class="flex items-start gap-4">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/toasts/2.html
+++ b/public/examples/application/toasts/2.html
@@ -10,6 +10,7 @@
     <div role="alert" class="rounded-md border border-red-500 bg-red-50 p-4 shadow-sm">
       <div class="flex items-start gap-4">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/toasts/3-dark.html
+++ b/public/examples/application/toasts/3-dark.html
@@ -13,6 +13,7 @@
     >
       <div class="flex items-start gap-4">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/toasts/3.html
+++ b/public/examples/application/toasts/3.html
@@ -10,6 +10,7 @@
     <div role="alert" class="rounded-md border border-amber-500 bg-amber-50 p-4 shadow-sm">
       <div class="flex items-start gap-4">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/toasts/4-dark.html
+++ b/public/examples/application/toasts/4-dark.html
@@ -13,6 +13,7 @@
     >
       <div class="flex items-start gap-4">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/toasts/4.html
+++ b/public/examples/application/toasts/4.html
@@ -10,6 +10,7 @@
     <div role="alert" class="rounded-md border border-blue-500 bg-blue-50 p-4 shadow-sm">
       <div class="flex items-start gap-4">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/toasts/5-dark.html
+++ b/public/examples/application/toasts/5-dark.html
@@ -13,6 +13,7 @@
     >
       <div class="flex items-start gap-4">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/toasts/5.html
+++ b/public/examples/application/toasts/5.html
@@ -10,6 +10,7 @@
     <div role="alert" class="rounded-md border border-blue-500 bg-blue-50 p-4 shadow-sm">
       <div class="flex items-start gap-4">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/toasts/6-dark.html
+++ b/public/examples/application/toasts/6-dark.html
@@ -13,6 +13,7 @@
     >
       <div class="flex items-center gap-2 text-blue-700 dark:text-blue-200">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/toasts/6.html
+++ b/public/examples/application/toasts/6.html
@@ -10,6 +10,7 @@
     <div role="alert" class="border-s-4 border-blue-700 bg-blue-50 p-4">
       <div class="flex items-center gap-2 text-blue-700">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/toggles/2-dark.html
+++ b/public/examples/application/toggles/2-dark.html
@@ -17,6 +17,7 @@
         class="absolute inset-y-0 start-0 m-1 grid size-6 place-content-center rounded-full bg-white text-gray-700 transition-[inset-inline-start] peer-checked:start-6 peer-checked:*:first:hidden *:last:hidden peer-checked:*:last:block dark:bg-gray-900 dark:text-gray-200"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -28,6 +29,7 @@
         </svg>
 
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/toggles/2.html
+++ b/public/examples/application/toggles/2.html
@@ -17,6 +17,7 @@
         class="absolute inset-y-0 start-0 m-1 grid size-6 place-content-center rounded-full bg-white text-gray-700 transition-[inset-inline-start] peer-checked:start-6 peer-checked:*:first:hidden *:last:hidden peer-checked:*:last:block"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -28,6 +29,7 @@
         </svg>
 
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/public/examples/application/vertical-menu/3-dark.html
+++ b/public/examples/application/vertical-menu/3-dark.html
@@ -14,6 +14,7 @@
           class="flex items-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-gray-700 dark:bg-gray-800 dark:text-gray-200"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -43,6 +44,7 @@
           class="flex items-center gap-2 rounded-lg px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -67,6 +69,7 @@
           class="flex items-center gap-2 rounded-lg px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -91,6 +94,7 @@
           class="flex items-center gap-2 rounded-lg px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -115,6 +119,7 @@
           class="flex items-center gap-2 rounded-lg px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"

--- a/public/examples/application/vertical-menu/3.html
+++ b/public/examples/application/vertical-menu/3.html
@@ -11,6 +11,7 @@
       <li>
         <a href="#" class="flex items-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-gray-700">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -40,6 +41,7 @@
           class="flex items-center gap-2 rounded-lg px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -64,6 +66,7 @@
           class="flex items-center gap-2 rounded-lg px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -88,6 +91,7 @@
           class="flex items-center gap-2 rounded-lg px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -112,6 +116,7 @@
           class="flex items-center gap-2 rounded-lg px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"

--- a/public/examples/application/vertical-menu/4-dark.html
+++ b/public/examples/application/vertical-menu/4-dark.html
@@ -14,6 +14,7 @@
           class="flex items-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-gray-700 dark:bg-gray-800 dark:text-gray-200"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -43,6 +44,7 @@
         >
           <div class="flex items-center gap-2">
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               class="size-5 opacity-75"
               fill="none"
@@ -74,6 +76,7 @@
           class="flex items-center gap-2 rounded-lg px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -99,6 +102,7 @@
         >
           <div class="flex items-center gap-2">
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               class="size-5 opacity-75"
               fill="none"
@@ -128,6 +132,7 @@
           class="flex items-center gap-2 rounded-lg px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"

--- a/public/examples/application/vertical-menu/4.html
+++ b/public/examples/application/vertical-menu/4.html
@@ -11,6 +11,7 @@
       <li>
         <a href="#" class="flex items-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-gray-700">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -41,6 +42,7 @@
         >
           <div class="flex items-center gap-2">
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               class="size-5 opacity-75"
               fill="none"
@@ -72,6 +74,7 @@
           class="flex items-center gap-2 rounded-lg px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -97,6 +100,7 @@
         >
           <div class="flex items-center gap-2">
             <svg
+              aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               class="size-5 opacity-75"
               fill="none"
@@ -128,6 +132,7 @@
           class="flex items-center gap-2 rounded-lg px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"

--- a/public/examples/application/vertical-menu/5-dark.html
+++ b/public/examples/application/vertical-menu/5-dark.html
@@ -14,6 +14,7 @@
           class="flex items-center gap-2 border-s-[3px] border-blue-500 bg-blue-50 px-4 py-3 text-blue-700 dark:bg-blue-500/20 dark:text-blue-50"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -43,6 +44,7 @@
           class="flex items-center gap-2 border-s-[3px] border-transparent px-4 py-3 text-gray-500 hover:border-gray-100 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:border-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-200"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -67,6 +69,7 @@
           class="flex items-center gap-2 border-s-[3px] border-transparent px-4 py-3 text-gray-500 hover:border-gray-100 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:border-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-200"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -91,6 +94,7 @@
           class="flex items-center gap-2 border-s-[3px] border-transparent px-4 py-3 text-gray-500 hover:border-gray-100 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:border-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-200"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -115,6 +119,7 @@
           class="flex items-center gap-2 border-s-[3px] border-transparent px-4 py-3 text-gray-500 hover:border-gray-100 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:border-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-200"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"

--- a/public/examples/application/vertical-menu/5.html
+++ b/public/examples/application/vertical-menu/5.html
@@ -14,6 +14,7 @@
           class="flex items-center gap-2 border-s-[3px] border-blue-500 bg-blue-50 px-4 py-3 text-blue-700"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -43,6 +44,7 @@
           class="flex items-center gap-2 border-s-[3px] border-transparent px-4 py-3 text-gray-500 hover:border-gray-100 hover:bg-gray-50 hover:text-gray-700"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -67,6 +69,7 @@
           class="flex items-center gap-2 border-s-[3px] border-transparent px-4 py-3 text-gray-500 hover:border-gray-100 hover:bg-gray-50 hover:text-gray-700"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -91,6 +94,7 @@
           class="flex items-center gap-2 border-s-[3px] border-transparent px-4 py-3 text-gray-500 hover:border-gray-100 hover:bg-gray-50 hover:text-gray-700"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -115,6 +119,7 @@
           class="flex items-center gap-2 border-s-[3px] border-transparent px-4 py-3 text-gray-500 hover:border-gray-100 hover:bg-gray-50 hover:text-gray-700"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"

--- a/public/examples/application/vertical-menu/6-dark.html
+++ b/public/examples/application/vertical-menu/6-dark.html
@@ -26,6 +26,7 @@
 
             <span class="shrink-0 transition duration-300 group-open:-rotate-180">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5"
                 viewBox="0 0 20 20"
@@ -89,6 +90,7 @@
 
             <span class="shrink-0 transition duration-300 group-open:-rotate-180">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5"
                 viewBox="0 0 20 20"

--- a/public/examples/application/vertical-menu/6.html
+++ b/public/examples/application/vertical-menu/6.html
@@ -26,6 +26,7 @@
 
             <span class="shrink-0 transition duration-300 group-open:-rotate-180">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5"
                 viewBox="0 0 20 20"
@@ -89,6 +90,7 @@
 
             <span class="shrink-0 transition duration-300 group-open:-rotate-180">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5"
                 viewBox="0 0 20 20"

--- a/public/examples/application/vertical-menu/7-dark.html
+++ b/public/examples/application/vertical-menu/7-dark.html
@@ -14,6 +14,7 @@
           class="flex items-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-gray-700 dark:bg-gray-800 dark:text-gray-200"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -44,6 +45,7 @@
           >
             <div class="flex items-center gap-2">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5 opacity-75"
                 fill="none"
@@ -63,6 +65,7 @@
 
             <span class="shrink-0 transition duration-300 group-open:-rotate-180">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5"
                 viewBox="0 0 20 20"
@@ -105,6 +108,7 @@
           class="flex items-center gap-2 rounded-lg px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -129,6 +133,7 @@
           class="flex items-center gap-2 rounded-lg px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -154,6 +159,7 @@
           >
             <div class="flex items-center gap-2">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5 opacity-75"
                 fill="none"
@@ -173,6 +179,7 @@
 
             <span class="shrink-0 transition duration-300 group-open:-rotate-180">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5"
                 viewBox="0 0 20 20"

--- a/public/examples/application/vertical-menu/7.html
+++ b/public/examples/application/vertical-menu/7.html
@@ -11,6 +11,7 @@
       <li>
         <a href="#" class="flex items-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-gray-700">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -41,6 +42,7 @@
           >
             <div class="flex items-center gap-2">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5 opacity-75"
                 fill="none"
@@ -60,6 +62,7 @@
 
             <span class="shrink-0 transition duration-300 group-open:-rotate-180">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5"
                 viewBox="0 0 20 20"
@@ -102,6 +105,7 @@
           class="flex items-center gap-2 rounded-lg px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -126,6 +130,7 @@
           class="flex items-center gap-2 rounded-lg px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             class="size-5 opacity-75"
             fill="none"
@@ -151,6 +156,7 @@
           >
             <div class="flex items-center gap-2">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5 opacity-75"
                 fill="none"
@@ -170,6 +176,7 @@
 
             <span class="shrink-0 transition duration-300 group-open:-rotate-180">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 class="size-5"
                 viewBox="0 0 20 20"


### PR DESCRIPTION
## Summary
- Add `aria-hidden` to decorative icons throughout the `application` examples
- Fix icon-only controls with no accessible name (button-groups View/Edit/Delete/Grid/List, side-menu nav links whose tooltip relied on `visibility:hidden`)
- Fix `steps` labels hidden from mobile screen readers (`hidden sm:inline` → `sr-only sm:not-sr-only`)
- Add `role="status"` + accessible names to `loaders`
- Wire up accessible names on `role="progressbar"` widgets that had none
- Add `<nav aria-label="Pagination">` and `aria-current="page"` to pagination
- Add `sr-only` "Increase"/"Decrease" text to `stats` trend indicators that were color/icon-only
- Fix a contrast failure on the modal close icon (`text-gray-400` → `text-gray-600`)

## Test plan
- [ ] Visually spot-check a few components in the browser (accordions, loaders, pagination, stats)
- [ ] `pnpm build` succeeds