### PR TITLE
Update - Fix accessibility issues across neobrutalism component examples

### DIFF
--- a/public/examples/neobrutalism/accordions/1-dark.html
+++ b/public/examples/neobrutalism/accordions/1-dark.html
@@ -15,6 +15,7 @@
           <span class="font-semibold">What are the basic features?</span>
 
           <svg
+            aria-hidden="true"
             class="size-5 shrink-0 group-open:-rotate-180"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -47,6 +48,7 @@
           <span class="font-semibold">How do I get started?</span>
 
           <svg
+            aria-hidden="true"
             class="size-5 shrink-0 group-open:-rotate-180"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -79,6 +81,7 @@
           <span class="font-semibold">What support options are available?</span>
 
           <svg
+            aria-hidden="true"
             class="size-5 shrink-0 group-open:-rotate-180"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"

--- a/public/examples/neobrutalism/accordions/1.html
+++ b/public/examples/neobrutalism/accordions/1.html
@@ -15,6 +15,7 @@
           <span class="font-semibold">What are the basic features?</span>
 
           <svg
+            aria-hidden="true"
             class="size-5 shrink-0 group-open:-rotate-180"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -47,6 +48,7 @@
           <span class="font-semibold">How do I get started?</span>
 
           <svg
+            aria-hidden="true"
             class="size-5 shrink-0 group-open:-rotate-180"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -79,6 +81,7 @@
           <span class="font-semibold">What support options are available?</span>
 
           <svg
+            aria-hidden="true"
             class="size-5 shrink-0 group-open:-rotate-180"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"

--- a/public/examples/neobrutalism/accordions/2-dark.html
+++ b/public/examples/neobrutalism/accordions/2-dark.html
@@ -17,6 +17,7 @@
           <span class="font-semibold">What are the basic features?</span>
 
           <svg
+            aria-hidden="true"
             class="size-5 shrink-0 group-open:-rotate-180"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -51,6 +52,7 @@
           <span class="font-semibold">How do I get started?</span>
 
           <svg
+            aria-hidden="true"
             class="size-5 shrink-0 group-open:-rotate-180"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -85,6 +87,7 @@
           <span class="font-semibold">What support options are available?</span>
 
           <svg
+            aria-hidden="true"
             class="size-5 shrink-0 group-open:-rotate-180"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"

--- a/public/examples/neobrutalism/accordions/2.html
+++ b/public/examples/neobrutalism/accordions/2.html
@@ -17,6 +17,7 @@
           <span class="font-semibold">What are the basic features?</span>
 
           <svg
+            aria-hidden="true"
             class="size-5 shrink-0 group-open:-rotate-180"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -51,6 +52,7 @@
           <span class="font-semibold">How do I get started?</span>
 
           <svg
+            aria-hidden="true"
             class="size-5 shrink-0 group-open:-rotate-180"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -85,6 +87,7 @@
           <span class="font-semibold">What support options are available?</span>
 
           <svg
+            aria-hidden="true"
             class="size-5 shrink-0 group-open:-rotate-180"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"

--- a/public/examples/neobrutalism/accordions/3-dark.html
+++ b/public/examples/neobrutalism/accordions/3-dark.html
@@ -17,6 +17,7 @@
           <span class="font-semibold">What are the basic features?</span>
 
           <svg
+            aria-hidden="true"
             class="size-5 shrink-0 group-open:-rotate-180"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -49,6 +50,7 @@
           <span class="font-semibold">How do I get started?</span>
 
           <svg
+            aria-hidden="true"
             class="size-5 shrink-0 group-open:-rotate-180"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -81,6 +83,7 @@
           <span class="font-semibold">What support options are available?</span>
 
           <svg
+            aria-hidden="true"
             class="size-5 shrink-0 group-open:-rotate-180"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"

--- a/public/examples/neobrutalism/accordions/3.html
+++ b/public/examples/neobrutalism/accordions/3.html
@@ -15,6 +15,7 @@
           <span class="font-semibold">What are the basic features?</span>
 
           <svg
+            aria-hidden="true"
             class="size-5 shrink-0 group-open:-rotate-180"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -47,6 +48,7 @@
           <span class="font-semibold">How do I get started?</span>
 
           <svg
+            aria-hidden="true"
             class="size-5 shrink-0 group-open:-rotate-180"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -79,6 +81,7 @@
           <span class="font-semibold">What support options are available?</span>
 
           <svg
+            aria-hidden="true"
             class="size-5 shrink-0 group-open:-rotate-180"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"

--- a/public/examples/neobrutalism/alerts/1-dark.html
+++ b/public/examples/neobrutalism/alerts/1-dark.html
@@ -13,6 +13,7 @@
     >
       <div class="flex items-start gap-3">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 16 16"
           fill="currentColor"
@@ -26,6 +27,7 @@
         </svg>
 
         <strong class="block flex-1 leading-tight font-semibold">
+          <span class="sr-only">Info: </span>
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Quas, eos!
         </strong>
       </div>

--- a/public/examples/neobrutalism/alerts/1.html
+++ b/public/examples/neobrutalism/alerts/1.html
@@ -13,6 +13,7 @@
     >
       <div class="flex items-start gap-3">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 16 16"
           fill="currentColor"
@@ -26,6 +27,7 @@
         </svg>
 
         <strong class="block flex-1 leading-tight font-semibold">
+          <span class="sr-only">Info: </span>
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Quas, eos!
         </strong>
       </div>

--- a/public/examples/neobrutalism/alerts/2-dark.html
+++ b/public/examples/neobrutalism/alerts/2-dark.html
@@ -13,6 +13,7 @@
     >
       <div class="flex items-start gap-3">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 16 16"
           fill="currentColor"
@@ -26,6 +27,7 @@
         </svg>
 
         <strong class="block flex-1 leading-tight font-semibold">
+          <span class="sr-only">Success: </span>
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Quas, eos!
         </strong>
       </div>

--- a/public/examples/neobrutalism/alerts/2.html
+++ b/public/examples/neobrutalism/alerts/2.html
@@ -13,6 +13,7 @@
     >
       <div class="flex items-start gap-3">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 16 16"
           fill="currentColor"
@@ -26,6 +27,7 @@
         </svg>
 
         <strong class="block flex-1 leading-tight font-semibold">
+          <span class="sr-only">Success: </span>
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Quas, eos!
         </strong>
       </div>

--- a/public/examples/neobrutalism/alerts/3-dark.html
+++ b/public/examples/neobrutalism/alerts/3-dark.html
@@ -13,6 +13,7 @@
     >
       <div class="flex items-start gap-3">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 16 16"
           fill="currentColor"
@@ -26,6 +27,7 @@
         </svg>
 
         <strong class="block flex-1 leading-tight font-semibold">
+          <span class="sr-only">Error: </span>
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Quas, eos!
         </strong>
       </div>

--- a/public/examples/neobrutalism/alerts/3.html
+++ b/public/examples/neobrutalism/alerts/3.html
@@ -13,6 +13,7 @@
     >
       <div class="flex items-start gap-3">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 16 16"
           fill="currentColor"
@@ -26,6 +27,7 @@
         </svg>
 
         <strong class="block flex-1 leading-tight font-semibold">
+          <span class="sr-only">Error: </span>
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Quas, eos!
         </strong>
       </div>

--- a/public/examples/neobrutalism/badges/3-dark.html
+++ b/public/examples/neobrutalism/badges/3-dark.html
@@ -15,8 +15,10 @@
       <button
         type="button"
         class="bg-black p-0.5 text-white shadow-[2px_2px_0_0] shadow-black hover:translate-0.5 hover:shadow-none focus:ring-2 focus:ring-yellow-300 dark:bg-white dark:text-gray-900 dark:shadow-white dark:focus:ring-yellow-600"
+        aria-label="Remove"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 16 16"
           fill="currentColor"

--- a/public/examples/neobrutalism/badges/3.html
+++ b/public/examples/neobrutalism/badges/3.html
@@ -15,8 +15,10 @@
       <button
         type="button"
         class="bg-black p-0.5 text-white shadow-[2px_2px_0_0] shadow-black hover:translate-0.5 hover:shadow-none focus:ring-2 focus:ring-yellow-300"
+        aria-label="Remove"
       >
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 16 16"
           fill="currentColor"

--- a/public/examples/neobrutalism/cards/1-dark.html
+++ b/public/examples/neobrutalism/cards/1-dark.html
@@ -13,6 +13,7 @@
     >
       <span class="inline-flex items-center gap-1.5">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 16 16"
           fill="currentColor"

--- a/public/examples/neobrutalism/cards/1.html
+++ b/public/examples/neobrutalism/cards/1.html
@@ -13,6 +13,7 @@
     >
       <span class="inline-flex items-center gap-1.5">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 16 16"
           fill="currentColor"

--- a/public/examples/neobrutalism/cards/2-dark.html
+++ b/public/examples/neobrutalism/cards/2-dark.html
@@ -13,6 +13,7 @@
     >
       <span class="inline-flex items-center gap-1.5">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 16 16"
           fill="currentColor"

--- a/public/examples/neobrutalism/cards/2.html
+++ b/public/examples/neobrutalism/cards/2.html
@@ -13,6 +13,7 @@
     >
       <span class="inline-flex items-center gap-1.5">
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 16 16"
           fill="currentColor"

--- a/public/examples/neobrutalism/cards/3-dark.html
+++ b/public/examples/neobrutalism/cards/3-dark.html
@@ -18,6 +18,7 @@
       >
         <span class="inline-flex items-center gap-1.5">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 16 16"
             fill="currentColor"

--- a/public/examples/neobrutalism/cards/3.html
+++ b/public/examples/neobrutalism/cards/3.html
@@ -16,6 +16,7 @@
       >
         <span class="inline-flex items-center gap-1.5">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 16 16"
             fill="currentColor"

--- a/public/examples/neobrutalism/inputs/2-dark.html
+++ b/public/examples/neobrutalism/inputs/2-dark.html
@@ -21,6 +21,7 @@
           class="absolute top-1 right-1 grid size-8 place-content-center bg-black text-white dark:bg-white dark:text-gray-900"
         >
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 16 16"
             fill="currentColor"

--- a/public/examples/neobrutalism/inputs/2.html
+++ b/public/examples/neobrutalism/inputs/2.html
@@ -19,6 +19,7 @@
 
         <span class="absolute top-1 right-1 grid size-8 place-content-center bg-black text-white">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 16 16"
             fill="currentColor"

--- a/public/examples/neobrutalism/progress-bars/1-dark.html
+++ b/public/examples/neobrutalism/progress-bars/1-dark.html
@@ -7,7 +7,13 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="mx-auto max-w-md p-6">
-    <div role="progressbar" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">
+    <div
+      role="progressbar"
+      aria-valuenow="25"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-label="Progress"
+    >
       <div
         class="w-full border-2 border-black bg-white p-1 shadow-[2px_2px_0_0] shadow-black dark:border-white dark:bg-gray-900 dark:shadow-white"
       >

--- a/public/examples/neobrutalism/progress-bars/1.html
+++ b/public/examples/neobrutalism/progress-bars/1.html
@@ -7,7 +7,13 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="mx-auto max-w-md p-6">
-    <div role="progressbar" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">
+    <div
+      role="progressbar"
+      aria-valuenow="25"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-label="Progress"
+    >
       <div class="w-full border-2 border-black bg-white p-1 shadow-[2px_2px_0_0] shadow-black">
         <div class="h-3 bg-black" style="width: 25%"></div>
       </div>

--- a/public/examples/neobrutalism/progress-bars/2-dark.html
+++ b/public/examples/neobrutalism/progress-bars/2-dark.html
@@ -7,7 +7,13 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="mx-auto max-w-md p-6">
-    <div role="progressbar" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">
+    <div
+      role="progressbar"
+      aria-valuenow="25"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-label="Progress"
+    >
       <div
         class="w-full border-2 border-black bg-white p-1 shadow-[2px_2px_0_0] shadow-black dark:border-white dark:bg-gray-900 dark:shadow-white"
       >

--- a/public/examples/neobrutalism/progress-bars/2.html
+++ b/public/examples/neobrutalism/progress-bars/2.html
@@ -7,7 +7,13 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="mx-auto max-w-md p-6">
-    <div role="progressbar" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">
+    <div
+      role="progressbar"
+      aria-valuenow="25"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-label="Progress"
+    >
       <div class="w-full border-2 border-black bg-white p-1 shadow-[2px_2px_0_0] shadow-black">
         <div
           class="h-3 bg-[repeating-linear-gradient(45deg,var(--tw-gradient-from)_0,var(--tw-gradient-from)_10px,var(--tw-gradient-to)_10px,var(--tw-gradient-to)_20px)] from-yellow-400 to-yellow-500"

--- a/public/examples/neobrutalism/progress-bars/3-dark.html
+++ b/public/examples/neobrutalism/progress-bars/3-dark.html
@@ -7,9 +7,15 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="mx-auto max-w-md p-6">
-    <div role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100">
+    <div
+      role="progressbar"
+      aria-valuenow="75"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-labelledby="UpdatingLabel"
+    >
       <div class="flex justify-between gap-4 text-black dark:text-white">
-        <span class="text-sm font-semibold">Updating</span>
+        <span id="UpdatingLabel" class="text-sm font-semibold">Updating</span>
 
         <span class="text-sm font-semibold">75%</span>
       </div>

--- a/public/examples/neobrutalism/progress-bars/3.html
+++ b/public/examples/neobrutalism/progress-bars/3.html
@@ -7,9 +7,15 @@
     <script src="/component.js" defer></script>
   </head>
   <body class="mx-auto max-w-md p-6">
-    <div role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100">
+    <div
+      role="progressbar"
+      aria-valuenow="75"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-labelledby="UpdatingLabel"
+    >
       <div class="flex justify-between gap-4 text-black">
-        <span class="text-sm font-semibold">Updating</span>
+        <span id="UpdatingLabel" class="text-sm font-semibold">Updating</span>
 
         <span class="text-sm font-semibold">75%</span>
       </div>

--- a/public/examples/neobrutalism/selects/3-dark.html
+++ b/public/examples/neobrutalism/selects/3-dark.html
@@ -21,6 +21,7 @@
 
         <span class="absolute inset-y-0 right-0 grid w-8 place-content-center">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 16 16"
             fill="currentColor"

--- a/public/examples/neobrutalism/selects/3.html
+++ b/public/examples/neobrutalism/selects/3.html
@@ -21,6 +21,7 @@
 
         <span class="absolute inset-y-0 right-0 grid w-8 place-content-center">
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 16 16"
             fill="currentColor"


### PR DESCRIPTION
## Summary
- Add `aria-hidden` to decorative icons throughout the `neobrutalism` examples
- Fix `alerts` whose type (info/success/error) was conveyed by icon shape and color alone — add `sr-only` labels
- Fix an icon-only remove button in `badges` with no accessible name
- Wire up accessible names on `role="progressbar"` widgets in `progress-bars` that had none

## Test plan
- [ ] Visually spot-check a few components in the browser (alerts, badges, progress-bars)
- [ ] `pnpm build` succeeds