### PR TITLE
Bugfix - Remove GitHub star banner

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -27,17 +27,6 @@ const { title, description } = Astro.props
 
     <SiteHeader />
 
-    <aside
-      class="border-b border-gray-200 bg-gray-50 p-4 text-center text-sm font-medium text-gray-700"
-    >
-      Enjoying HyperUI? Consider <a
-        href="https://github.com/markmead/hyperui"
-        class="underline transition-colors hover:text-gray-900"
-        target="_blank"
-        rel="noreferrer">starring the repository on GitHub</a
-      > to show your support!
-    </aside>
-
     <div class="flex flex-1 flex-col *:w-full">
       <slot />
     </div>


### PR DESCRIPTION
## Summary

- Remove the "Enjoying HyperUI? Consider starring the repository on GitHub to show your support!" banner from `src/layouts/BaseLayout.astro`

## Test plan

- [x] Verified no other occurrences of the banner text exist in the codebase

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJeH1iZ8A5wo29oa66sYWo)_