### PR TITLE
Bugfix - Give dark example HTML files an explicit dark background

### DIFF
--- a/public/examples/application/accordions/1-dark.html
+++ b/public/examples/application/accordions/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="space-y-2">
       <details class="group [&_summary::-webkit-details-marker]:hidden">
         <summary

--- a/public/examples/application/accordions/2-dark.html
+++ b/public/examples/application/accordions/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="space-y-2">
       <details class="group [&_summary::-webkit-details-marker]:hidden">
         <summary

--- a/public/examples/application/accordions/3-dark.html
+++ b/public/examples/application/accordions/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="-mx-4 -my-2 space-y-0 divide-y divide-gray-200 dark:divide-gray-700">
       <details class="group px-4 py-3 [&_summary::-webkit-details-marker]:hidden">
         <summary

--- a/public/examples/application/accordions/4-dark.html
+++ b/public/examples/application/accordions/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="space-y-2">
       <details class="group space-y-2 [&_summary::-webkit-details-marker]:hidden" open>
         <summary

--- a/public/examples/application/accordions/5-dark.html
+++ b/public/examples/application/accordions/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="space-y-1">
       <details class="group [&_summary::-webkit-details-marker]:hidden">
         <summary

--- a/public/examples/application/badges/1-dark.html
+++ b/public/examples/application/badges/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex flex-wrap justify-center gap-4 p-6">
+  <body class="flex flex-wrap justify-center gap-4 p-6 dark:bg-gray-900">
     <span
       class="rounded-full bg-purple-100 px-2.5 py-0.5 text-sm whitespace-nowrap text-purple-700 dark:bg-purple-700 dark:text-purple-100"
     >

--- a/public/examples/application/badges/2-dark.html
+++ b/public/examples/application/badges/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex flex-wrap justify-center gap-4 p-6">
+  <body class="flex flex-wrap justify-center gap-4 p-6 dark:bg-gray-900">
     <span
       class="inline-flex items-center justify-center rounded-full bg-purple-100 px-2.5 py-0.5 text-purple-700 dark:bg-purple-700 dark:text-purple-100"
     >

--- a/public/examples/application/badges/3-dark.html
+++ b/public/examples/application/badges/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex flex-wrap justify-center gap-4 p-6">
+  <body class="flex flex-wrap justify-center gap-4 p-6 dark:bg-gray-900">
     <span
       class="inline-flex items-center justify-center rounded-full bg-purple-100 px-2.5 py-0.5 text-purple-700 dark:bg-purple-700 dark:text-purple-100"
     >

--- a/public/examples/application/badges/4-dark.html
+++ b/public/examples/application/badges/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex flex-wrap justify-center gap-4 p-6">
+  <body class="flex flex-wrap justify-center gap-4 p-6 dark:bg-gray-900">
     <span
       class="inline-flex items-center justify-center rounded-full bg-purple-100 px-2.5 py-1 text-purple-700 dark:bg-purple-700 dark:text-purple-100"
     >

--- a/public/examples/application/badges/5-dark.html
+++ b/public/examples/application/badges/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex flex-wrap justify-center gap-4 p-6">
+  <body class="flex flex-wrap justify-center gap-4 p-6 dark:bg-gray-900">
     <span
       class="inline-flex items-center justify-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-emerald-700 dark:bg-emerald-700 dark:text-emerald-100"
     >

--- a/public/examples/application/breadcrumbs/1-dark.html
+++ b/public/examples/application/breadcrumbs/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <nav aria-label="Breadcrumb">
       <ol class="flex items-center gap-1 text-sm text-gray-700 dark:text-gray-200">
         <li>

--- a/public/examples/application/breadcrumbs/2-dark.html
+++ b/public/examples/application/breadcrumbs/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <nav aria-label="Breadcrumb">
       <ol class="flex items-center gap-1 text-sm text-gray-700 dark:text-gray-200">
         <li>

--- a/public/examples/application/breadcrumbs/3-dark.html
+++ b/public/examples/application/breadcrumbs/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <nav aria-label="Breadcrumb">
       <ol class="flex items-center gap-1 text-sm text-gray-700 dark:text-gray-200">
         <li>

--- a/public/examples/application/breadcrumbs/4-dark.html
+++ b/public/examples/application/breadcrumbs/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <nav aria-label="Breadcrumb">
       <ol class="flex items-center gap-1 text-sm text-gray-700 dark:text-gray-200">
         <li>

--- a/public/examples/application/breadcrumbs/5-dark.html
+++ b/public/examples/application/breadcrumbs/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <nav aria-label="Breadcrumb">
       <ol
         class="flex overflow-hidden rounded border border-gray-300 bg-white text-sm text-gray-700 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200"

--- a/public/examples/application/button-groups/1-dark.html
+++ b/public/examples/application/button-groups/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <div class="inline-flex">
       <button
         class="rounded-s-sm border border-gray-200 px-3 py-2 font-medium text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:z-10 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white dark:focus:ring-offset-gray-900"

--- a/public/examples/application/button-groups/2-dark.html
+++ b/public/examples/application/button-groups/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <div class="inline-flex">
       <button
         class="rounded-s-sm border border-gray-200 px-3 py-2 text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:z-10 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white dark:focus:ring-offset-gray-900"

--- a/public/examples/application/button-groups/3-dark.html
+++ b/public/examples/application/button-groups/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <div class="inline-flex">
       <button
         class="rounded-s-sm border border-gray-200 px-4 py-2 font-medium text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:z-10 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white dark:focus:ring-offset-gray-900"

--- a/public/examples/application/button-groups/4-dark.html
+++ b/public/examples/application/button-groups/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <div class="inline-flex gap-2">
       <button
         class="rounded-sm border border-gray-200 p-2 text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white dark:focus:ring-offset-gray-900"

--- a/public/examples/application/button-groups/5-dark.html
+++ b/public/examples/application/button-groups/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <div class="inline-flex">
       <button
         class="rounded-s-sm border border-gray-200 p-2 text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:z-10 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:pointer-events-auto disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white dark:focus:ring-offset-gray-900"

--- a/public/examples/application/charts/1-dark.html
+++ b/public/examples/application/charts/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <div class="rounded-lg border border-gray-800 bg-gray-900 p-6">
       <div class="flex items-center justify-between">
         <h2 class="text-sm font-medium text-white">Monthly revenue</h2>

--- a/public/examples/application/charts/10-dark.html
+++ b/public/examples/application/charts/10-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <div class="rounded-lg border border-gray-800 bg-gray-900 p-6">
       <h2 class="text-sm font-medium text-white">Ad spend vs conversions</h2>
 

--- a/public/examples/application/charts/11-dark.html
+++ b/public/examples/application/charts/11-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <div class="rounded-lg border border-gray-800 bg-gray-900 p-6">
       <h2 class="text-sm font-medium text-white">Campaign performance</h2>
 

--- a/public/examples/application/charts/2-dark.html
+++ b/public/examples/application/charts/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <div class="rounded-lg border border-gray-800 bg-gray-900 p-6">
       <h2 class="text-sm font-medium text-white">Orders this week</h2>
 

--- a/public/examples/application/charts/3-dark.html
+++ b/public/examples/application/charts/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <div class="rounded-lg border border-gray-800 bg-gray-900 p-6">
       <h2 class="text-sm font-medium text-white">Orders by status</h2>
 

--- a/public/examples/application/charts/4-dark.html
+++ b/public/examples/application/charts/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-sm p-6">
+  <body class="mx-auto max-w-sm p-6 dark:bg-gray-900">
     <div
       class="flex items-center justify-between gap-4 rounded-lg border border-gray-800 bg-gray-900 p-6"
     >

--- a/public/examples/application/charts/5-dark.html
+++ b/public/examples/application/charts/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <div class="rounded-lg border border-gray-800 bg-gray-900 p-6">
       <h2 class="text-sm font-medium text-white">Traffic by channel</h2>
 

--- a/public/examples/application/charts/6-dark.html
+++ b/public/examples/application/charts/6-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <div class="rounded-lg border border-gray-800 bg-gray-900 p-6">
       <h2 class="text-sm font-medium text-white">Revenue vs target</h2>
 

--- a/public/examples/application/charts/7-dark.html
+++ b/public/examples/application/charts/7-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <div class="rounded-lg border border-gray-800 bg-gray-900 p-6">
       <h2 class="text-sm font-medium text-white">Revenue: this year vs last year</h2>
 

--- a/public/examples/application/charts/8-dark.html
+++ b/public/examples/application/charts/8-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-sm p-6">
+  <body class="mx-auto max-w-sm p-6 dark:bg-gray-900">
     <div class="rounded-lg border border-gray-800 bg-gray-900 p-6">
       <h2 class="text-sm font-medium text-white">Team performance</h2>
 

--- a/public/examples/application/charts/9-dark.html
+++ b/public/examples/application/charts/9-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-sm p-6">
+  <body class="mx-auto max-w-sm p-6 dark:bg-gray-900">
     <div class="rounded-lg border border-gray-800 bg-gray-900 p-6">
       <h2 class="text-sm font-medium text-white">Traffic sources</h2>
 

--- a/public/examples/application/checkboxes/1-dark.html
+++ b/public/examples/application/checkboxes/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <fieldset>
       <legend class="sr-only">Checkboxes</legend>
 

--- a/public/examples/application/checkboxes/2-dark.html
+++ b/public/examples/application/checkboxes/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <fieldset>
       <legend class="sr-only">Checkboxes</legend>
 

--- a/public/examples/application/checkboxes/3-dark.html
+++ b/public/examples/application/checkboxes/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <fieldset>
       <legend class="sr-only">Checkboxes</legend>
 

--- a/public/examples/application/details-list/1-dark.html
+++ b/public/examples/application/details-list/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="flow-root">
       <dl class="-my-3 divide-y divide-gray-200 text-sm dark:divide-gray-700">
         <div class="grid grid-cols-1 gap-1 py-3 sm:grid-cols-3 sm:gap-4">

--- a/public/examples/application/details-list/2-dark.html
+++ b/public/examples/application/details-list/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="flow-root">
       <dl
         class="-my-3 divide-y divide-gray-200 text-sm *:even:bg-gray-50 dark:divide-gray-700 dark:*:even:bg-gray-800"

--- a/public/examples/application/details-list/3-dark.html
+++ b/public/examples/application/details-list/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="flow-root">
       <dl
         class="-my-3 divide-y divide-gray-200 rounded border border-gray-200 text-sm dark:divide-gray-700 dark:border-gray-800"

--- a/public/examples/application/details-list/4-dark.html
+++ b/public/examples/application/details-list/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="flow-root">
       <dl
         class="-my-3 divide-y divide-gray-200 rounded border border-gray-200 text-sm *:even:bg-gray-50 dark:divide-gray-700 dark:border-gray-800 dark:*:even:bg-gray-800"

--- a/public/examples/application/dividers/1-dark.html
+++ b/public/examples/application/dividers/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <span class="flex items-center">
       <span class="h-px flex-1 bg-gray-300 dark:bg-gray-600"></span>
 

--- a/public/examples/application/dividers/2-dark.html
+++ b/public/examples/application/dividers/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <span class="flex items-center">
       <span class="h-px flex-1 bg-linear-to-r from-transparent to-gray-300 dark:to-gray-600"></span>
 

--- a/public/examples/application/dividers/3-dark.html
+++ b/public/examples/application/dividers/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <span class="flex items-center">
       <span class="shrink-0 pe-4 text-gray-900 dark:text-white"> Title goes here </span>
 

--- a/public/examples/application/dividers/4-dark.html
+++ b/public/examples/application/dividers/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <span class="flex items-center">
       <span class="shrink-0 pe-4 text-gray-900 dark:text-white"> Title goes here </span>
 

--- a/public/examples/application/dividers/5-dark.html
+++ b/public/examples/application/dividers/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <span class="flex items-center">
       <span class="h-px flex-1 bg-gray-300 dark:bg-gray-600"></span>
 

--- a/public/examples/application/dividers/6-dark.html
+++ b/public/examples/application/dividers/6-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <span class="flex items-center">
       <span class="h-px flex-1 bg-linear-to-r from-transparent to-gray-300 dark:to-gray-600"></span>
 

--- a/public/examples/application/dropdown/1-dark.html
+++ b/public/examples/application/dropdown/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto flex max-w-sm justify-center p-6">
+  <body class="mx-auto flex max-w-sm justify-center p-6 dark:bg-gray-900">
     <div class="relative inline-flex">
       <span
         class="inline-flex divide-x divide-gray-300 overflow-hidden rounded border border-gray-300 bg-white shadow-sm dark:divide-gray-600 dark:border-gray-600 dark:bg-gray-800"

--- a/public/examples/application/dropdown/2-dark.html
+++ b/public/examples/application/dropdown/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto flex max-w-sm justify-center p-6">
+  <body class="mx-auto flex max-w-sm justify-center p-6 dark:bg-gray-900">
     <div class="relative inline-flex">
       <span
         class="inline-flex divide-x divide-gray-300 overflow-hidden rounded border border-gray-300 bg-white shadow-sm dark:divide-gray-600 dark:border-gray-600 dark:bg-gray-800"

--- a/public/examples/application/dropdown/3-dark.html
+++ b/public/examples/application/dropdown/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto flex max-w-sm justify-center p-6">
+  <body class="mx-auto flex max-w-sm justify-center p-6 dark:bg-gray-900">
     <div class="relative inline-flex">
       <span
         class="inline-flex divide-x divide-gray-300 overflow-hidden rounded border border-gray-300 bg-white shadow-sm dark:divide-gray-600 dark:border-gray-600 dark:bg-gray-800"

--- a/public/examples/application/empty-states/1-dark.html
+++ b/public/examples/application/empty-states/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex min-h-screen items-center justify-center p-6">
+  <body class="flex min-h-screen items-center justify-center p-6 dark:bg-gray-900">
     <div class="max-w-md text-center">
       <svg
         aria-hidden="true"

--- a/public/examples/application/empty-states/2-dark.html
+++ b/public/examples/application/empty-states/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex min-h-screen items-center justify-center p-6">
+  <body class="flex min-h-screen items-center justify-center p-6 dark:bg-gray-900">
     <div class="max-w-md text-center">
       <svg
         aria-hidden="true"

--- a/public/examples/application/empty-states/3-dark.html
+++ b/public/examples/application/empty-states/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex min-h-screen items-center justify-center p-6">
+  <body class="flex min-h-screen items-center justify-center p-6 dark:bg-gray-900">
     <div class="max-w-md text-center">
       <svg
         aria-hidden="true"

--- a/public/examples/application/empty-states/4-dark.html
+++ b/public/examples/application/empty-states/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex min-h-screen items-center justify-center p-6">
+  <body class="flex min-h-screen items-center justify-center p-6 dark:bg-gray-900">
     <div class="max-w-md text-center">
       <svg
         aria-hidden="true"

--- a/public/examples/application/empty-states/5-dark.html
+++ b/public/examples/application/empty-states/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex min-h-screen items-center justify-center p-6">
+  <body class="flex min-h-screen items-center justify-center p-6 dark:bg-gray-900">
     <div class="max-w-md text-center">
       <svg
         aria-hidden="true"

--- a/public/examples/application/file-uploaders/1-dark.html
+++ b/public/examples/application/file-uploaders/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-md p-6">
+  <body class="mx-auto max-w-md p-6 dark:bg-gray-900">
     <label
       for="File"
       class="block rounded border border-gray-300 bg-white p-4 text-gray-900 shadow-sm sm:p-6 dark:border-gray-700 dark:bg-gray-900 dark:text-white"

--- a/public/examples/application/file-uploaders/2-dark.html
+++ b/public/examples/application/file-uploaders/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-md p-6">
+  <body class="mx-auto max-w-md p-6 dark:bg-gray-900">
     <label
       for="File"
       class="flex flex-col items-center rounded border border-gray-300 bg-white p-4 text-gray-900 shadow-sm sm:p-6 dark:border-gray-700 dark:bg-gray-900 dark:text-white"

--- a/public/examples/application/filters/1-dark.html
+++ b/public/examples/application/filters/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-md p-6">
+  <body class="mx-auto max-w-md p-6 dark:bg-gray-900">
     <div class="flex gap-4 sm:gap-6">
       <details class="group relative">
         <summary

--- a/public/examples/application/filters/2-dark.html
+++ b/public/examples/application/filters/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-md p-6">
+  <body class="mx-auto max-w-md p-6 dark:bg-gray-900">
     <div class="space-y-4">
       <details
         class="group relative overflow-hidden rounded border border-gray-300 shadow-sm dark:border-gray-600"

--- a/public/examples/application/inputs/1-dark.html
+++ b/public/examples/application/inputs/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-sm p-6">
+  <body class="mx-auto max-w-sm p-6 dark:bg-gray-900">
     <label for="Email">
       <span class="text-sm font-medium text-gray-700 dark:text-gray-200"> Email </span>
 

--- a/public/examples/application/inputs/2-dark.html
+++ b/public/examples/application/inputs/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-sm p-6">
+  <body class="mx-auto max-w-sm p-6 dark:bg-gray-900">
     <label for="Email">
       <span class="text-sm font-medium text-gray-700 dark:text-gray-200"> Email </span>
 

--- a/public/examples/application/inputs/3-dark.html
+++ b/public/examples/application/inputs/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-sm p-6">
+  <body class="mx-auto max-w-sm p-6 dark:bg-gray-900">
     <label for="Search">
       <span class="text-sm font-medium text-gray-700 dark:text-gray-200"> Search </span>
 

--- a/public/examples/application/inputs/4-dark.html
+++ b/public/examples/application/inputs/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-sm p-6">
+  <body class="mx-auto max-w-sm p-6 dark:bg-gray-900">
     <label for="Email" class="relative">
       <input
         type="email"

--- a/public/examples/application/loaders/1-dark.html
+++ b/public/examples/application/loaders/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex min-h-screen items-center justify-center p-6">
+  <body class="flex min-h-screen items-center justify-center p-6 dark:bg-gray-900">
     <div role="status" aria-label="Loading">
       <svg
         class="mx-auto size-8 animate-spin text-indigo-600 dark:text-indigo-300"

--- a/public/examples/application/loaders/2-dark.html
+++ b/public/examples/application/loaders/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex min-h-screen items-center justify-center p-6">
+  <body class="flex min-h-screen items-center justify-center p-6 dark:bg-gray-900">
     <div class="text-center" role="status">
       <svg
         class="mx-auto size-8 animate-spin text-indigo-600 dark:text-indigo-300"

--- a/public/examples/application/loaders/3-dark.html
+++ b/public/examples/application/loaders/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex min-h-screen items-center justify-center p-6">
+  <body class="flex min-h-screen items-center justify-center p-6 dark:bg-gray-900">
     <div class="inline-flex items-center gap-3" role="status">
       <svg
         class="size-6 animate-spin text-indigo-600 dark:text-indigo-300"

--- a/public/examples/application/loaders/4-dark.html
+++ b/public/examples/application/loaders/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex min-h-screen items-center justify-center p-6">
+  <body class="flex min-h-screen items-center justify-center p-6 dark:bg-gray-900">
     <div class="w-full max-w-sm" role="status">
       <div class="h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
         <div class="h-full w-[80%] animate-pulse bg-indigo-600 dark:bg-indigo-300"></div>

--- a/public/examples/application/loaders/5-dark.html
+++ b/public/examples/application/loaders/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex min-h-screen items-center justify-center p-6">
+  <body class="flex min-h-screen items-center justify-center p-6 dark:bg-gray-900">
     <div class="flex gap-2" role="status" aria-label="Loading">
       <span
         class="size-3 animate-pulse rounded-full bg-indigo-600 dark:bg-indigo-300"

--- a/public/examples/application/loaders/6-dark.html
+++ b/public/examples/application/loaders/6-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex min-h-screen items-center justify-center p-6">
+  <body class="flex min-h-screen items-center justify-center p-6 dark:bg-gray-900">
     <div class="flex gap-2" role="status" aria-label="Loading">
       <span
         class="size-3 animate-ping rounded-full bg-indigo-600 dark:bg-indigo-300"

--- a/public/examples/application/loaders/7-dark.html
+++ b/public/examples/application/loaders/7-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex min-h-screen items-center justify-center p-6">
+  <body class="flex min-h-screen items-center justify-center p-6 dark:bg-gray-900">
     <div class="flex gap-2" role="status" aria-label="Loading">
       <span
         class="size-3 animate-bounce rounded-full bg-indigo-600 dark:bg-indigo-300"

--- a/public/examples/application/modals/1-dark.html
+++ b/public/examples/application/modals/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="p-6">
+  <body class="p-6 dark:bg-gray-900">
     <button
       data-modal-open
       class="rounded border border-gray-300 bg-gray-100 px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-white"

--- a/public/examples/application/modals/2-dark.html
+++ b/public/examples/application/modals/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="p-6">
+  <body class="p-6 dark:bg-gray-900">
     <button
       data-modal-open
       class="rounded border border-gray-300 bg-gray-100 px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-white"

--- a/public/examples/application/modals/3-dark.html
+++ b/public/examples/application/modals/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="p-6">
+  <body class="p-6 dark:bg-gray-900">
     <button
       data-modal-open
       class="rounded border border-gray-300 bg-gray-100 px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-white"

--- a/public/examples/application/modals/4-dark.html
+++ b/public/examples/application/modals/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="p-6">
+  <body class="p-6 dark:bg-gray-900">
     <button
       data-modal-open
       class="rounded border border-gray-300 bg-gray-100 px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-white"

--- a/public/examples/application/modals/5-dark.html
+++ b/public/examples/application/modals/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="p-6">
+  <body class="p-6 dark:bg-gray-900">
     <button
       data-modal-open
       class="rounded border border-gray-300 bg-gray-100 px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-white"

--- a/public/examples/application/modals/6-dark.html
+++ b/public/examples/application/modals/6-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="p-6">
+  <body class="p-6 dark:bg-gray-900">
     <button
       data-modal-open
       class="rounded border border-gray-300 bg-gray-100 px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-white"

--- a/public/examples/application/pagination/1-dark.html
+++ b/public/examples/application/pagination/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <nav aria-label="Pagination">
       <ul class="flex justify-center gap-1 text-gray-900 dark:text-white">
         <li>

--- a/public/examples/application/pagination/2-dark.html
+++ b/public/examples/application/pagination/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <nav aria-label="Pagination">
       <ul class="flex justify-center gap-1 text-gray-900 dark:text-white">
         <li>

--- a/public/examples/application/pagination/3-dark.html
+++ b/public/examples/application/pagination/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <nav aria-label="Pagination">
       <ul class="flex justify-center gap-3 text-gray-900 dark:text-white">
         <li>

--- a/public/examples/application/quantity-inputs/1-dark.html
+++ b/public/examples/application/quantity-inputs/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <div>
       <label for="Quantity" class="sr-only"> Quantity </label>
 

--- a/public/examples/application/quantity-inputs/2-dark.html
+++ b/public/examples/application/quantity-inputs/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <div>
       <label for="Quantity" class="sr-only"> Quantity </label>
 

--- a/public/examples/application/quantity-inputs/3-dark.html
+++ b/public/examples/application/quantity-inputs/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <div>
       <label for="Quantity" class="sr-only"> Quantity </label>
 

--- a/public/examples/application/quantity-inputs/4-dark.html
+++ b/public/examples/application/quantity-inputs/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <div>
       <label for="Quantity" class="sr-only"> Quantity </label>
 

--- a/public/examples/application/radio-groups/1-dark.html
+++ b/public/examples/application/radio-groups/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <fieldset class="space-y-3">
       <legend class="sr-only">Delivery</legend>
 

--- a/public/examples/application/radio-groups/2-dark.html
+++ b/public/examples/application/radio-groups/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <fieldset class="space-y-3">
       <legend class="sr-only">Delivery</legend>
 

--- a/public/examples/application/selects/1-dark.html
+++ b/public/examples/application/selects/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-xs p-6">
+  <body class="mx-auto max-w-xs p-6 dark:bg-gray-900">
     <label for="Headline">
       <span class="text-sm font-medium text-gray-700 dark:text-gray-200"> Headliner </span>
 

--- a/public/examples/application/selects/2-dark.html
+++ b/public/examples/application/selects/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-xs p-6">
+  <body class="mx-auto max-w-xs p-6 dark:bg-gray-900">
     <label for="Headline">
       <span class="text-sm font-medium text-gray-700 dark:text-gray-200"> Headliner </span>
 

--- a/public/examples/application/selects/3-dark.html
+++ b/public/examples/application/selects/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-xs p-6">
+  <body class="mx-auto max-w-xs p-6 dark:bg-gray-900">
     <label for="Headline">
       <span class="text-sm font-medium text-gray-700 dark:text-gray-200"> Headliner </span>
 

--- a/public/examples/application/side-menu/1-dark.html
+++ b/public/examples/application/side-menu/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="max-w-xs">
+  <body class="max-w-xs dark:bg-gray-900">
     <div
       class="flex h-screen flex-col justify-between border-e border-gray-100 bg-white dark:border-gray-800 dark:bg-gray-900"
     >

--- a/public/examples/application/side-menu/2-dark.html
+++ b/public/examples/application/side-menu/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="max-w-xs">
+  <body class="max-w-xs dark:bg-gray-900">
     <div
       class="flex h-screen w-16 flex-col justify-between border-e border-gray-100 bg-white dark:border-gray-800 dark:bg-gray-900"
     >

--- a/public/examples/application/stats/1-dark.html
+++ b/public/examples/application/stats/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto flex max-w-lg flex-col gap-4 p-6">
+  <body class="mx-auto flex max-w-lg flex-col gap-4 p-6 dark:bg-gray-900">
     <article
       class="flex flex-col gap-4 rounded-lg border border-gray-100 bg-white p-6 dark:border-gray-800 dark:bg-gray-900"
     >

--- a/public/examples/application/stats/2-dark.html
+++ b/public/examples/application/stats/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto flex max-w-lg flex-col gap-4 p-6">
+  <body class="mx-auto flex max-w-lg flex-col gap-4 p-6 dark:bg-gray-900">
     <article
       class="flex items-end justify-between rounded-lg border border-gray-100 bg-white p-6 dark:border-gray-800 dark:bg-gray-900"
     >

--- a/public/examples/application/stats/3-dark.html
+++ b/public/examples/application/stats/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto flex max-w-lg flex-col gap-4 p-6">
+  <body class="mx-auto flex max-w-lg flex-col gap-4 p-6 dark:bg-gray-900">
     <article
       class="flex items-end justify-between rounded-lg border border-gray-100 bg-white p-6 dark:border-gray-800 dark:bg-gray-900"
     >

--- a/public/examples/application/stats/4-dark.html
+++ b/public/examples/application/stats/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto flex max-w-lg flex-col gap-4 p-6">
+  <body class="mx-auto flex max-w-lg flex-col gap-4 p-6 dark:bg-gray-900">
     <article
       class="flex items-center gap-4 rounded-lg border border-gray-100 bg-white p-6 dark:border-gray-800 dark:bg-gray-900"
     >

--- a/public/examples/application/stats/5-dark.html
+++ b/public/examples/application/stats/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto flex max-w-lg flex-col gap-4 p-6">
+  <body class="mx-auto flex max-w-lg flex-col gap-4 p-6 dark:bg-gray-900">
     <article
       class="rounded-lg border border-gray-100 bg-white p-6 dark:border-gray-800 dark:bg-gray-900"
     >

--- a/public/examples/application/stats/6-dark.html
+++ b/public/examples/application/stats/6-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto flex max-w-lg flex-col gap-4 p-6">
+  <body class="mx-auto flex max-w-lg flex-col gap-4 p-6 dark:bg-gray-900">
     <article
       class="rounded-lg border border-gray-100 bg-white p-6 dark:border-gray-800 dark:bg-gray-900"
     >

--- a/public/examples/application/steps/1-dark.html
+++ b/public/examples/application/steps/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div>
       <h2 class="sr-only">Steps</h2>
 

--- a/public/examples/application/steps/2-dark.html
+++ b/public/examples/application/steps/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div>
       <h2 class="sr-only">Steps</h2>
 

--- a/public/examples/application/steps/3-dark.html
+++ b/public/examples/application/steps/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div>
       <h2 class="sr-only">Steps</h2>
 

--- a/public/examples/application/steps/4-dark.html
+++ b/public/examples/application/steps/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div>
       <h2 class="sr-only">Steps</h2>
 

--- a/public/examples/application/steps/5-dark.html
+++ b/public/examples/application/steps/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div>
       <h2 class="sr-only">Steps</h2>
 

--- a/public/examples/application/tables/1-dark.html
+++ b/public/examples/application/tables/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="overflow-x-auto">
       <table class="min-w-full divide-y-2 divide-gray-200 dark:divide-gray-700">
         <thead class="ltr:text-left rtl:text-right">

--- a/public/examples/application/tables/2-dark.html
+++ b/public/examples/application/tables/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="overflow-x-auto rounded border border-gray-300 shadow-sm dark:border-gray-600">
       <table class="min-w-full divide-y-2 divide-gray-200 dark:divide-gray-700">
         <thead class="ltr:text-left rtl:text-right">

--- a/public/examples/application/tables/3-dark.html
+++ b/public/examples/application/tables/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="overflow-x-auto">
       <table class="min-w-full divide-y-2 divide-gray-200 dark:divide-gray-700">
         <thead class="ltr:text-left rtl:text-right">

--- a/public/examples/application/tables/4-dark.html
+++ b/public/examples/application/tables/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="max-h-46 overflow-x-auto">
       <table class="min-w-full divide-y-2 divide-gray-200 dark:divide-gray-700">
         <thead class="sticky top-0 bg-white ltr:text-left rtl:text-right dark:bg-gray-900">

--- a/public/examples/application/tables/5-dark.html
+++ b/public/examples/application/tables/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="overflow-x-auto">
       <table class="min-w-full divide-y-2 divide-gray-200 dark:divide-gray-700">
         <thead class="ltr:text-left rtl:text-right">

--- a/public/examples/application/tabs/1-dark.html
+++ b/public/examples/application/tabs/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="-mb-px border-b border-gray-200 dark:border-gray-700">
       <div role="tablist" class="flex gap-1">
         <button

--- a/public/examples/application/tabs/2-dark.html
+++ b/public/examples/application/tabs/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="border-b border-gray-200 dark:border-gray-700">
       <div role="tablist" class="-mb-px flex gap-4">
         <button

--- a/public/examples/application/tabs/3-dark.html
+++ b/public/examples/application/tabs/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="flex gap-4">
       <div class="border-r border-gray-200 dark:border-gray-700">
         <div role="tablist" class="-me-px flex flex-col gap-1">

--- a/public/examples/application/tabs/4-dark.html
+++ b/public/examples/application/tabs/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div role="tablist" class="flex gap-2">
       <button
         role="tab"

--- a/public/examples/application/tabs/5-dark.html
+++ b/public/examples/application/tabs/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div role="tablist" class="flex gap-2">
       <button
         role="tab"

--- a/public/examples/application/textareas/1-dark.html
+++ b/public/examples/application/textareas/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <label for="Notes">
       <span class="text-sm font-medium text-gray-700 dark:text-gray-200"> Notes </span>
 

--- a/public/examples/application/textareas/2-dark.html
+++ b/public/examples/application/textareas/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <div>
       <label for="Notes">
         <span class="text-sm font-medium text-gray-700 dark:text-gray-200"> Notes </span>

--- a/public/examples/application/textareas/3-dark.html
+++ b/public/examples/application/textareas/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <div>
       <label for="Notes">
         <span class="text-sm font-medium text-gray-700 dark:text-gray-200"> Notes </span>

--- a/public/examples/application/timelines/1-dark.html
+++ b/public/examples/application/timelines/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-xl p-6">
+  <body class="mx-auto max-w-xl p-6 dark:bg-gray-900">
     <ol
       class="relative space-y-8 before:absolute before:-ms-px before:h-full before:w-0.5 before:rounded-full before:bg-gray-200 dark:before:bg-gray-700"
     >

--- a/public/examples/application/timelines/2-dark.html
+++ b/public/examples/application/timelines/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-xl p-6">
+  <body class="mx-auto max-w-xl p-6 dark:bg-gray-900">
     <ol
       class="relative space-y-8 before:absolute before:top-0 before:left-1/2 before:h-full before:w-0.5 before:-translate-x-1/2 before:rounded-full before:bg-gray-200 dark:before:bg-gray-700"
     >

--- a/public/examples/application/timelines/3-dark.html
+++ b/public/examples/application/timelines/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-5xl p-6">
+  <body class="mx-auto max-w-5xl p-6 dark:bg-gray-900">
     <ol
       class="relative flex gap-8 before:absolute before:-mt-px before:h-0.5 before:w-full before:rounded-full before:bg-gray-200 dark:before:bg-gray-700"
     >

--- a/public/examples/application/toasts/1-dark.html
+++ b/public/examples/application/toasts/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="ml-auto max-w-md p-6">
+  <body class="ml-auto max-w-md p-6 dark:bg-gray-900">
     <div
       role="alert"
       class="rounded-md border border-green-500 bg-green-50 p-4 shadow-sm dark:border-green-400 dark:bg-green-800"

--- a/public/examples/application/toasts/2-dark.html
+++ b/public/examples/application/toasts/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="ml-auto max-w-md p-6">
+  <body class="ml-auto max-w-md p-6 dark:bg-gray-900">
     <div
       role="alert"
       class="rounded-md border border-red-500 bg-red-50 p-4 shadow-sm dark:border-red-400 dark:bg-red-800"

--- a/public/examples/application/toasts/3-dark.html
+++ b/public/examples/application/toasts/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="ml-auto max-w-md p-6">
+  <body class="ml-auto max-w-md p-6 dark:bg-gray-900">
     <div
       role="alert"
       class="rounded-md border border-amber-500 bg-amber-50 p-4 shadow-sm dark:border-amber-400 dark:bg-amber-800"

--- a/public/examples/application/toasts/4-dark.html
+++ b/public/examples/application/toasts/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="ml-auto max-w-md p-6">
+  <body class="ml-auto max-w-md p-6 dark:bg-gray-900">
     <div
       role="alert"
       class="rounded-md border border-blue-500 bg-blue-50 p-4 shadow-sm dark:border-blue-400 dark:bg-blue-800"

--- a/public/examples/application/toasts/5-dark.html
+++ b/public/examples/application/toasts/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="ml-auto max-w-md p-6">
+  <body class="ml-auto max-w-md p-6 dark:bg-gray-900">
     <div
       role="alert"
       class="rounded-md border border-blue-500 bg-blue-50 p-4 shadow-sm dark:border-blue-400 dark:bg-blue-800"

--- a/public/examples/application/toasts/6-dark.html
+++ b/public/examples/application/toasts/6-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="ml-auto max-w-md p-6">
+  <body class="ml-auto max-w-md p-6 dark:bg-gray-900">
     <div
       role="alert"
       class="border-s-4 border-blue-700 bg-blue-50 p-4 dark:border-blue-600 dark:bg-blue-800"

--- a/public/examples/application/toggles/1-dark.html
+++ b/public/examples/application/toggles/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <label
       for="AcceptConditions"
       class="relative block h-8 w-14 rounded-full bg-gray-300 transition-colors [-webkit-tap-highlight-color:transparent] has-checked:bg-green-500 dark:bg-gray-600 dark:has-checked:bg-green-600"

--- a/public/examples/application/toggles/2-dark.html
+++ b/public/examples/application/toggles/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <label
       for="AcceptConditions"
       class="relative block h-8 w-14 rounded-full bg-gray-300 transition-colors [-webkit-tap-highlight-color:transparent] has-checked:bg-green-500 dark:bg-gray-600 dark:has-checked:bg-green-600"

--- a/public/examples/application/toggles/3-dark.html
+++ b/public/examples/application/toggles/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <label
       for="AcceptConditions"
       class="relative block h-8 w-12 [-webkit-tap-highlight-color:transparent]"

--- a/public/examples/application/toggles/4-dark.html
+++ b/public/examples/application/toggles/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <label
       for="AcceptConditions"
       class="relative block h-8 w-14 rounded-full bg-gray-300 transition-colors [-webkit-tap-highlight-color:transparent] has-checked:bg-blue-500 dark:bg-gray-600 dark:has-checked:bg-blue-600"

--- a/public/examples/application/vertical-menu/1-dark.html
+++ b/public/examples/application/vertical-menu/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-sm p-6">
+  <body class="mx-auto max-w-sm p-6 dark:bg-gray-900">
     <ul class="space-y-1">
       <li>
         <a

--- a/public/examples/application/vertical-menu/2-dark.html
+++ b/public/examples/application/vertical-menu/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-sm p-6">
+  <body class="mx-auto max-w-sm p-6 dark:bg-gray-900">
     <ul class="space-y-1">
       <li>
         <a

--- a/public/examples/application/vertical-menu/3-dark.html
+++ b/public/examples/application/vertical-menu/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-sm p-6">
+  <body class="mx-auto max-w-sm p-6 dark:bg-gray-900">
     <ul class="space-y-1">
       <li>
         <a

--- a/public/examples/application/vertical-menu/4-dark.html
+++ b/public/examples/application/vertical-menu/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-sm p-6">
+  <body class="mx-auto max-w-sm p-6 dark:bg-gray-900">
     <ul class="space-y-1">
       <li>
         <a

--- a/public/examples/application/vertical-menu/5-dark.html
+++ b/public/examples/application/vertical-menu/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-sm p-6">
+  <body class="mx-auto max-w-sm p-6 dark:bg-gray-900">
     <ul>
       <li>
         <a

--- a/public/examples/application/vertical-menu/6-dark.html
+++ b/public/examples/application/vertical-menu/6-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-sm p-6">
+  <body class="mx-auto max-w-sm p-6 dark:bg-gray-900">
     <ul class="space-y-1">
       <li>
         <a

--- a/public/examples/application/vertical-menu/7-dark.html
+++ b/public/examples/application/vertical-menu/7-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-sm p-6">
+  <body class="mx-auto max-w-sm p-6 dark:bg-gray-900">
     <ul class="space-y-1">
       <li>
         <a

--- a/public/examples/application/vertical-menu/8-dark.html
+++ b/public/examples/application/vertical-menu/8-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-sm p-6">
+  <body class="mx-auto max-w-sm p-6 dark:bg-gray-900">
     <div class="flow-root">
       <ul class="-my-2 divide-y divide-gray-100 dark:divide-gray-800">
         <li class="py-2">

--- a/public/examples/marketing/announcements/1-dark.html
+++ b/public/examples/marketing/announcements/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div
       class="border-b border-gray-200 bg-gray-100 px-4 py-2 text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
     >

--- a/public/examples/marketing/announcements/2-dark.html
+++ b/public/examples/marketing/announcements/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div
       class="flex items-center justify-between border-b border-gray-200 bg-gray-100 px-4 py-2 text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
     >

--- a/public/examples/marketing/announcements/3-dark.html
+++ b/public/examples/marketing/announcements/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div
       class="fixed inset-x-0 bottom-0 z-auto border-t border-gray-200 bg-gray-100 px-4 py-2 text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
     >

--- a/public/examples/marketing/announcements/4-dark.html
+++ b/public/examples/marketing/announcements/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div
       class="fixed inset-x-0 bottom-0 z-auto flex items-center justify-between border-t border-gray-200 bg-gray-100 px-4 py-2 text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
     >

--- a/public/examples/marketing/announcements/5-dark.html
+++ b/public/examples/marketing/announcements/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div class="fixed inset-x-0 bottom-0 z-auto p-4">
       <div
         class="rounded border border-gray-200 bg-gray-100 px-4 py-2 text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-white"

--- a/public/examples/marketing/announcements/6-dark.html
+++ b/public/examples/marketing/announcements/6-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div class="fixed inset-x-0 bottom-0 z-auto p-4">
       <div
         class="flex items-center justify-between rounded border border-gray-200 bg-gray-100 px-4 py-2 text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-white"

--- a/public/examples/marketing/banners/1-dark.html
+++ b/public/examples/marketing/banners/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <section class="bg-white lg:grid lg:h-screen lg:place-content-center dark:bg-gray-900">
       <div class="mx-auto w-screen max-w-7xl px-4 py-16 sm:px-6 sm:py-24 lg:px-8 lg:py-32">
         <div class="mx-auto max-w-prose text-center">

--- a/public/examples/marketing/banners/2-dark.html
+++ b/public/examples/marketing/banners/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <section class="bg-white lg:grid lg:h-screen lg:place-content-center dark:bg-gray-900">
       <div class="mx-auto w-screen max-w-7xl px-4 py-16 sm:px-6 sm:py-24 lg:px-8 lg:py-32">
         <div class="max-w-prose">

--- a/public/examples/marketing/banners/3-dark.html
+++ b/public/examples/marketing/banners/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <section class="bg-white lg:grid lg:h-screen lg:place-content-center dark:bg-gray-900">
       <div
         class="mx-auto w-screen max-w-7xl px-4 py-16 sm:px-6 sm:py-24 md:grid md:grid-cols-2 md:items-center md:gap-4 lg:px-8 lg:py-32"

--- a/public/examples/marketing/blog-cards/1-dark.html
+++ b/public/examples/marketing/blog-cards/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-md p-6">
+  <body class="mx-auto max-w-md p-6 dark:bg-gray-900">
     <article
       class="overflow-hidden rounded-lg shadow-sm transition hover:shadow-lg dark:shadow-gray-700/25"
     >

--- a/public/examples/marketing/blog-cards/2-dark.html
+++ b/public/examples/marketing/blog-cards/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-md p-6">
+  <body class="mx-auto max-w-md p-6 dark:bg-gray-900">
     <article class="group">
       <img
         alt=""

--- a/public/examples/marketing/blog-cards/3-dark.html
+++ b/public/examples/marketing/blog-cards/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-md p-6">
+  <body class="mx-auto max-w-md p-6 dark:bg-gray-900">
     <article
       class="overflow-hidden rounded-lg border border-gray-100 bg-white shadow-xs dark:border-gray-800 dark:bg-gray-900 dark:shadow-gray-700/25"
     >

--- a/public/examples/marketing/blog-cards/4-dark.html
+++ b/public/examples/marketing/blog-cards/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-md p-6">
+  <body class="mx-auto max-w-md p-6 dark:bg-gray-900">
     <article
       class="rounded-[10px] border border-gray-200 bg-white px-4 pt-12 pb-4 dark:border-gray-700 dark:bg-gray-900"
     >

--- a/public/examples/marketing/blog-cards/5-dark.html
+++ b/public/examples/marketing/blog-cards/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-md p-6">
+  <body class="mx-auto max-w-md p-6 dark:bg-gray-900">
     <article
       class="rounded-lg border border-gray-100 bg-white p-4 shadow-xs transition hover:shadow-lg sm:p-6 dark:border-gray-800 dark:bg-gray-900 dark:shadow-gray-700/25"
     >

--- a/public/examples/marketing/blog-cards/6-dark.html
+++ b/public/examples/marketing/blog-cards/6-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <article
       class="flex bg-white transition hover:shadow-xl dark:bg-gray-900 dark:shadow-gray-800/25"
     >

--- a/public/examples/marketing/buttons/1-dark.html
+++ b/public/examples/marketing/buttons/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex flex-wrap justify-center gap-4 p-6">
+  <body class="flex flex-wrap justify-center gap-4 p-6 dark:bg-gray-900">
     <a
       class="inline-flex items-center justify-center rounded-full border border-indigo-600 bg-indigo-600 px-6 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-indigo-700 focus-visible:ring-4 focus-visible:ring-indigo-200 focus-visible:outline-none dark:border-indigo-300 dark:bg-indigo-300 dark:text-gray-900 dark:hover:bg-indigo-200 dark:focus-visible:ring-indigo-700"
       href="#"

--- a/public/examples/marketing/buttons/2-dark.html
+++ b/public/examples/marketing/buttons/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex flex-wrap justify-center gap-4 p-6">
+  <body class="flex flex-wrap justify-center gap-4 p-6 dark:bg-gray-900">
     <a
       class="inline-flex items-center gap-2 rounded-full border border-indigo-600 bg-indigo-600 px-6 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-indigo-700 focus-visible:ring-4 focus-visible:ring-indigo-200 focus-visible:outline-none dark:border-indigo-300 dark:bg-indigo-300 dark:text-gray-900 dark:hover:bg-indigo-200 dark:focus-visible:ring-indigo-700"
       href="#"

--- a/public/examples/marketing/buttons/3-dark.html
+++ b/public/examples/marketing/buttons/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex flex-wrap justify-center gap-4 p-6">
+  <body class="flex flex-wrap justify-center gap-4 p-6 dark:bg-gray-900">
     <a
       class="inline-flex size-12 items-center justify-center rounded-full border border-indigo-600 bg-indigo-600 text-white shadow-sm transition-colors hover:bg-indigo-700 focus-visible:ring-4 focus-visible:ring-indigo-200 focus-visible:outline-none dark:border-indigo-300 dark:bg-indigo-300 dark:text-gray-900 dark:hover:bg-indigo-200 dark:focus-visible:ring-indigo-700"
       href="#"

--- a/public/examples/marketing/buttons/4-dark.html
+++ b/public/examples/marketing/buttons/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex flex-wrap justify-center gap-4 p-6">
+  <body class="flex flex-wrap justify-center gap-4 p-6 dark:bg-gray-900">
     <a
       class="group inline-flex items-center gap-4 rounded-full border border-indigo-600 bg-indigo-600 px-5 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-indigo-700 focus-visible:ring-4 focus-visible:ring-indigo-200 focus-visible:outline-none dark:border-indigo-300 dark:bg-indigo-300 dark:text-gray-900 dark:hover:bg-indigo-200 dark:focus-visible:ring-indigo-700"
       href="#"

--- a/public/examples/marketing/buttons/5-dark.html
+++ b/public/examples/marketing/buttons/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex flex-wrap justify-center gap-4 p-6">
+  <body class="flex flex-wrap justify-center gap-4 p-6 dark:bg-gray-900">
     <a
       class="inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-semibold text-indigo-600 underline decoration-slate-300 decoration-2 underline-offset-4 transition-colors hover:text-indigo-700 hover:decoration-indigo-500 focus-visible:ring-4 focus-visible:ring-indigo-200 focus-visible:outline-none dark:text-indigo-300 dark:decoration-slate-600 dark:hover:text-indigo-200 dark:hover:decoration-indigo-400 dark:focus-visible:ring-indigo-700"
       href="#"

--- a/public/examples/marketing/carts/1-dark.html
+++ b/public/examples/marketing/carts/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-end p-6">
+  <body class="flex justify-end p-6 dark:bg-gray-900">
     <div
       class="relative w-screen max-w-sm border border-gray-300 bg-gray-100 px-4 py-8 sm:px-6 lg:px-8 dark:border-gray-600 dark:bg-gray-800"
       aria-modal="true"

--- a/public/examples/marketing/carts/2-dark.html
+++ b/public/examples/marketing/carts/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-end p-6">
+  <body class="flex justify-end p-6 dark:bg-gray-900">
     <div
       class="relative w-screen max-w-sm border border-gray-300 bg-gray-100 px-4 py-8 sm:px-6 lg:px-8 dark:border-gray-600 dark:bg-gray-800"
       aria-modal="true"

--- a/public/examples/marketing/carts/3-dark.html
+++ b/public/examples/marketing/carts/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
       <ul class="space-y-4">
         <li class="flex items-center gap-4">

--- a/public/examples/marketing/contact-forms/1-dark.html
+++ b/public/examples/marketing/contact-forms/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="p-6">
+  <body class="p-6 dark:bg-gray-900">
     <form
       action="#"
       class="mx-auto max-w-md space-y-4 rounded-lg border border-gray-300 bg-gray-100 p-6 dark:border-gray-600 dark:bg-gray-800"

--- a/public/examples/marketing/contact-forms/2-dark.html
+++ b/public/examples/marketing/contact-forms/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="p-6">
+  <body class="p-6 dark:bg-gray-900">
     <form
       action="#"
       class="mx-auto max-w-md space-y-4 rounded-lg border border-gray-300 bg-gray-100 p-6 dark:border-gray-600 dark:bg-gray-800"

--- a/public/examples/marketing/contact-forms/3-dark.html
+++ b/public/examples/marketing/contact-forms/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="p-6">
+  <body class="p-6 dark:bg-gray-900">
     <form
       action="#"
       class="mx-auto max-w-md space-y-4 rounded-lg border border-gray-300 bg-gray-100 p-6 dark:border-gray-600 dark:bg-gray-800"

--- a/public/examples/marketing/contact-forms/4-dark.html
+++ b/public/examples/marketing/contact-forms/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="p-6">
+  <body class="p-6 dark:bg-gray-900">
     <form
       action="#"
       class="mx-auto grid max-w-lg grid-cols-1 gap-4 rounded-lg border border-gray-300 bg-gray-100 p-6 sm:grid-cols-2 dark:border-gray-600 dark:bg-gray-800"

--- a/public/examples/marketing/contact-forms/5-dark.html
+++ b/public/examples/marketing/contact-forms/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
       <div class="grid grid-cols-1 gap-8 md:grid-cols-2">
         <div class="md:py-4">

--- a/public/examples/marketing/ctas/1-dark.html
+++ b/public/examples/marketing/ctas/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <section class="overflow-hidden bg-gray-50 sm:grid sm:grid-cols-2 dark:bg-gray-900">
       <div class="p-8 md:p-12 lg:px-16 lg:py-24">
         <div class="mx-auto max-w-xl text-center ltr:sm:text-left rtl:sm:text-right">

--- a/public/examples/marketing/ctas/2-dark.html
+++ b/public/examples/marketing/ctas/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <section class="bg-gray-50 dark:bg-gray-900">
       <div class="p-8 md:p-12 lg:px-16 lg:py-24">
         <div class="mx-auto max-w-lg text-center">

--- a/public/examples/marketing/ctas/3-dark.html
+++ b/public/examples/marketing/ctas/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <section
       class="overflow-hidden bg-gray-50 sm:grid sm:grid-cols-2 sm:items-center dark:bg-gray-900"
     >

--- a/public/examples/marketing/ctas/4-dark.html
+++ b/public/examples/marketing/ctas/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <section>
       <div class="mx-auto max-w-screen-2xl px-4 py-8 sm:px-6 lg:px-8">
         <div class="grid grid-cols-1 gap-4 md:grid-cols-2">

--- a/public/examples/marketing/empty-content/1-dark.html
+++ b/public/examples/marketing/empty-content/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex min-h-screen items-center justify-center p-6">
+  <body class="flex min-h-screen items-center justify-center p-6 dark:bg-gray-900">
     <div class="max-w-md text-center">
       <svg
         aria-hidden="true"

--- a/public/examples/marketing/empty-content/2-dark.html
+++ b/public/examples/marketing/empty-content/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex min-h-screen items-center justify-center p-6">
+  <body class="flex min-h-screen items-center justify-center p-6 dark:bg-gray-900">
     <div class="max-w-md text-center">
       <svg
         aria-hidden="true"

--- a/public/examples/marketing/empty-content/3-dark.html
+++ b/public/examples/marketing/empty-content/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex min-h-screen items-center justify-center p-6">
+  <body class="flex min-h-screen items-center justify-center p-6 dark:bg-gray-900">
     <div class="max-w-md text-center">
       <h2 class="text-2xl font-bold text-gray-900 dark:text-white">Coming soon!</h2>
 

--- a/public/examples/marketing/empty-content/4-dark.html
+++ b/public/examples/marketing/empty-content/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex min-h-screen items-center justify-center p-6">
+  <body class="flex min-h-screen items-center justify-center p-6 dark:bg-gray-900">
     <div class="max-w-md text-center">
       <svg
         aria-hidden="true"

--- a/public/examples/marketing/empty-content/5-dark.html
+++ b/public/examples/marketing/empty-content/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex min-h-screen items-center justify-center p-6">
+  <body class="flex min-h-screen items-center justify-center p-6 dark:bg-gray-900">
     <div class="max-w-md text-center">
       <svg
         aria-hidden="true"

--- a/public/examples/marketing/faqs/1-dark.html
+++ b/public/examples/marketing/faqs/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="space-y-4">
       <details class="group [&_summary::-webkit-details-marker]:hidden" open>
         <summary

--- a/public/examples/marketing/faqs/2-dark.html
+++ b/public/examples/marketing/faqs/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="flow-root">
       <div class="-my-4 flex flex-col divide-y divide-gray-200 dark:divide-gray-700">
         <details class="group py-4 [&_summary::-webkit-details-marker]:hidden" open>

--- a/public/examples/marketing/faqs/3-dark.html
+++ b/public/examples/marketing/faqs/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="space-y-4">
       <details
         class="group border-s-4 border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800 [&_summary::-webkit-details-marker]:hidden"

--- a/public/examples/marketing/feature-grids/1-dark.html
+++ b/public/examples/marketing/feature-grids/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
       <div class="mx-auto max-w-lg text-center">
         <h2 class="text-3xl/tight font-bold text-gray-900 sm:text-4xl dark:text-white">

--- a/public/examples/marketing/feature-grids/2-dark.html
+++ b/public/examples/marketing/feature-grids/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
       <div class="grid grid-cols-1 gap-8 md:grid-cols-2">
         <div class="col-span-1">

--- a/public/examples/marketing/feature-grids/3-dark.html
+++ b/public/examples/marketing/feature-grids/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
       <div class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
         <div class="text-center">

--- a/public/examples/marketing/feature-grids/4-dark.html
+++ b/public/examples/marketing/feature-grids/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
       <div class="grid grid-cols-1 gap-8 md:grid-cols-2">
         <div

--- a/public/examples/marketing/footers/1-dark.html
+++ b/public/examples/marketing/footers/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <footer class="bg-white dark:bg-gray-900">
       <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
         <div class="lg:flex lg:items-start lg:gap-8">

--- a/public/examples/marketing/footers/10-dark.html
+++ b/public/examples/marketing/footers/10-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <footer class="bg-white dark:bg-gray-900">
       <div class="mx-auto max-w-7xl px-4 pt-16 pb-6 sm:px-6 lg:px-8 lg:pt-24">
         <div class="grid grid-cols-1 gap-8 lg:grid-cols-3">

--- a/public/examples/marketing/footers/11-dark.html
+++ b/public/examples/marketing/footers/11-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <footer class="bg-gray-50 dark:bg-gray-900">
       <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <div class="sm:flex sm:items-center sm:justify-between">

--- a/public/examples/marketing/footers/12-dark.html
+++ b/public/examples/marketing/footers/12-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <footer class="bg-white dark:bg-gray-900">
       <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
         <div

--- a/public/examples/marketing/footers/2-dark.html
+++ b/public/examples/marketing/footers/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <footer class="bg-white dark:bg-gray-900">
       <div class="mx-auto max-w-7xl space-y-8 px-4 py-16 sm:px-6 lg:space-y-16 lg:px-8">
         <div class="sm:flex sm:items-center sm:justify-between">

--- a/public/examples/marketing/footers/3-dark.html
+++ b/public/examples/marketing/footers/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <footer class="bg-white dark:bg-gray-900">
       <div class="mx-auto max-w-7xl space-y-8 px-4 py-16 sm:px-6 lg:space-y-16 lg:px-8">
         <div class="grid grid-cols-1 gap-8 lg:grid-cols-3">

--- a/public/examples/marketing/footers/4-dark.html
+++ b/public/examples/marketing/footers/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <footer class="bg-white dark:bg-gray-900">
       <div class="mx-auto max-w-7xl px-4 pt-16 pb-8 sm:px-6 lg:px-8 lg:pt-24">
         <div class="text-center">

--- a/public/examples/marketing/footers/5-dark.html
+++ b/public/examples/marketing/footers/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <footer class="bg-white lg:grid lg:grid-cols-5 dark:bg-gray-900">
       <div class="relative block h-32 lg:col-span-2 lg:h-full">
         <img

--- a/public/examples/marketing/footers/6-dark.html
+++ b/public/examples/marketing/footers/6-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <footer class="bg-white dark:bg-gray-900">
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div class="lg:grid lg:grid-cols-2">

--- a/public/examples/marketing/footers/7-dark.html
+++ b/public/examples/marketing/footers/7-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <footer class="bg-white dark:bg-gray-900">
       <div class="mx-auto max-w-7xl px-4 pt-16 pb-8 sm:px-6 lg:px-8">
         <div class="mx-auto max-w-md">

--- a/public/examples/marketing/footers/8-dark.html
+++ b/public/examples/marketing/footers/8-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <footer class="bg-gray-100 dark:bg-gray-900">
       <div class="mx-auto max-w-5xl px-4 py-16 sm:px-6 lg:px-8">
         <div class="flex justify-center text-teal-600 dark:text-teal-300">

--- a/public/examples/marketing/footers/9-dark.html
+++ b/public/examples/marketing/footers/9-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <footer class="bg-gray-100 dark:bg-gray-900">
       <div class="relative mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8 lg:pt-24">
         <div class="absolute end-4 top-4 sm:end-6 sm:top-6 lg:end-8 lg:top-8">

--- a/public/examples/marketing/headers/1-dark.html
+++ b/public/examples/marketing/headers/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <header class="bg-white dark:bg-gray-900">
       <div class="mx-auto flex h-16 max-w-7xl items-center gap-8 px-4 sm:px-6 lg:px-8">
         <a class="block text-teal-600 dark:text-teal-300" href="#">

--- a/public/examples/marketing/headers/2-dark.html
+++ b/public/examples/marketing/headers/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <header class="bg-white dark:bg-gray-900">
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div class="flex h-16 items-center justify-between">

--- a/public/examples/marketing/headers/3-dark.html
+++ b/public/examples/marketing/headers/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <header class="bg-white dark:bg-gray-900">
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div class="flex h-16 items-center justify-between">

--- a/public/examples/marketing/headers/4-dark.html
+++ b/public/examples/marketing/headers/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <header class="bg-white dark:bg-gray-900">
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div class="flex h-16 items-center justify-between">

--- a/public/examples/marketing/newsletter-signup/1-dark.html
+++ b/public/examples/marketing/newsletter-signup/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div class="bg-gray-100 dark:bg-gray-800">
       <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <div class="max-w-prose">

--- a/public/examples/marketing/newsletter-signup/2-dark.html
+++ b/public/examples/marketing/newsletter-signup/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div class="bg-gray-100 dark:bg-gray-800">
       <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <div class="mx-auto max-w-prose text-center">

--- a/public/examples/marketing/polls/1-dark.html
+++ b/public/examples/marketing/polls/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
       <div class="max-w-prose">
         <h2 class="text-2xl font-semibold text-gray-900 sm:text-3xl dark:text-white">

--- a/public/examples/marketing/polls/2-dark.html
+++ b/public/examples/marketing/polls/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
       <div class="max-w-prose">
         <h2 class="text-2xl font-semibold text-gray-900 sm:text-3xl dark:text-white">

--- a/public/examples/marketing/polls/3-dark.html
+++ b/public/examples/marketing/polls/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-md p-6">
+  <body class="mx-auto max-w-md p-6 dark:bg-gray-900">
     <!--
       This is a pure HTML implementation.
       Highlighting all previous stars when selecting a rating is not possible without additional JavaScript.

--- a/public/examples/marketing/stats/1-dark.html
+++ b/public/examples/marketing/stats/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 sm:py-12 lg:px-8">
       <div class="mx-auto max-w-3xl text-center">
         <h2 class="text-3xl font-bold text-gray-900 sm:text-4xl dark:text-white">

--- a/public/examples/marketing/stats/2-dark.html
+++ b/public/examples/marketing/stats/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 sm:py-12 lg:px-8">
       <div class="mx-auto max-w-3xl text-center">
         <h2 class="text-3xl font-bold text-gray-900 sm:text-4xl dark:text-white">

--- a/public/examples/marketing/stats/3-dark.html
+++ b/public/examples/marketing/stats/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 sm:py-12 lg:px-8">
       <div class="mx-auto max-w-3xl text-center">
         <h2 class="text-3xl font-bold text-gray-900 sm:text-4xl dark:text-white">

--- a/public/examples/marketing/team-sections/1-dark.html
+++ b/public/examples/marketing/team-sections/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
       <div class="grid grid-cols-1 gap-8 md:grid-cols-3">
         <div>

--- a/public/examples/marketing/team-sections/2-dark.html
+++ b/public/examples/marketing/team-sections/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
       <div class="grid grid-cols-1 gap-8 md:grid-cols-3">
         <div>

--- a/public/examples/marketing/team-sections/3-dark.html
+++ b/public/examples/marketing/team-sections/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body>
+  <body class="dark:bg-gray-900">
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
       <div class="grid grid-cols-2 gap-8 sm:grid-cols-3 lg:grid-cols-6">
         <div>

--- a/public/examples/neobrutalism/accordions/1-dark.html
+++ b/public/examples/neobrutalism/accordions/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="space-y-3">
       <details class="group [&_summary::-webkit-details-marker]:hidden">
         <summary

--- a/public/examples/neobrutalism/accordions/2-dark.html
+++ b/public/examples/neobrutalism/accordions/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="space-y-3">
       <details
         class="group border-2 border-black shadow-[4px_4px_0_0] shadow-black dark:border-white dark:shadow-white [&_summary::-webkit-details-marker]:hidden"

--- a/public/examples/neobrutalism/accordions/3-dark.html
+++ b/public/examples/neobrutalism/accordions/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div
       class="divide-y-2 divide-black border-2 border-black shadow-[4px_4px_0_0] shadow-black dark:divide-white dark:border-white dark:shadow-white"
     >

--- a/public/examples/neobrutalism/alerts/1-dark.html
+++ b/public/examples/neobrutalism/alerts/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-md p-6">
+  <body class="mx-auto max-w-md p-6 dark:bg-gray-900">
     <div
       role="alert"
       class="border-2 bg-blue-100 p-4 text-blue-900 shadow-[4px_4px_0_0] shadow-black dark:bg-blue-800 dark:text-blue-50 dark:shadow-white"

--- a/public/examples/neobrutalism/alerts/2-dark.html
+++ b/public/examples/neobrutalism/alerts/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-md p-6">
+  <body class="mx-auto max-w-md p-6 dark:bg-gray-900">
     <div
       role="alert"
       class="border-2 bg-green-100 p-4 text-green-900 shadow-[4px_4px_0_0] shadow-black dark:bg-green-800 dark:text-green-50 dark:shadow-white"

--- a/public/examples/neobrutalism/alerts/3-dark.html
+++ b/public/examples/neobrutalism/alerts/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-md p-6">
+  <body class="mx-auto max-w-md p-6 dark:bg-gray-900">
     <div
       role="alert"
       class="border-2 bg-red-100 p-4 text-red-900 shadow-[4px_4px_0_0] shadow-black dark:bg-red-800 dark:text-red-50 dark:shadow-white"

--- a/public/examples/neobrutalism/badges/1-dark.html
+++ b/public/examples/neobrutalism/badges/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex flex-wrap justify-center gap-4 p-6">
+  <body class="flex flex-wrap justify-center gap-4 p-6 dark:bg-gray-900">
     <span
       class="border-2 border-black bg-blue-100 px-3 py-1.5 text-sm/none font-semibold text-black shadow-[2px_2px_0_0] shadow-black dark:border-white dark:bg-blue-800 dark:text-white dark:shadow-white"
     >

--- a/public/examples/neobrutalism/badges/2-dark.html
+++ b/public/examples/neobrutalism/badges/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex flex-wrap justify-center gap-4 p-6">
+  <body class="flex flex-wrap justify-center gap-4 p-6 dark:bg-gray-900">
     <span
       class="inline-flex items-center gap-1.5 border-2 border-black bg-white px-3 py-1.5 text-sm/none font-semibold text-black shadow-[2px_2px_0_0] shadow-black dark:border-white dark:bg-gray-900 dark:text-white dark:shadow-white"
     >

--- a/public/examples/neobrutalism/badges/3-dark.html
+++ b/public/examples/neobrutalism/badges/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <span
       class="inline-flex items-center gap-3 border-2 border-black bg-white px-3 py-1.5 text-sm/none font-semibold text-black shadow-[2px_2px_0_0] shadow-black dark:border-white dark:bg-gray-900 dark:text-white dark:shadow-white"
     >

--- a/public/examples/neobrutalism/buttons/1-dark.html
+++ b/public/examples/neobrutalism/buttons/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <a
       class="border-2 border-black bg-white px-5 py-3 font-semibold text-black shadow-[4px_4px_0_0] shadow-black hover:bg-yellow-200 focus:ring-2 focus:ring-yellow-300 focus:outline-0 dark:border-white dark:bg-gray-900 dark:text-white dark:shadow-white dark:hover:bg-yellow-700 dark:focus:ring-yellow-600"
       href="#"

--- a/public/examples/neobrutalism/buttons/2-dark.html
+++ b/public/examples/neobrutalism/buttons/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <a
       class="border-2 border-black bg-white px-5 py-3 font-semibold text-black shadow-[4px_4px_0_0] shadow-black hover:translate-1 hover:shadow-none focus:ring-2 focus:ring-yellow-300 focus:outline-0 dark:border-white dark:bg-gray-900 dark:text-white dark:shadow-white dark:focus:ring-yellow-600"
       href="#"

--- a/public/examples/neobrutalism/buttons/3-dark.html
+++ b/public/examples/neobrutalism/buttons/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <a
       class="border-2 border-black bg-white px-5 py-3 font-semibold text-black shadow-[4px_4px_0_0] shadow-black hover:translate-1 hover:shadow-[-1px_-1px_0_0] focus:ring-2 focus:ring-yellow-300 focus:outline-0 dark:border-white dark:bg-gray-900 dark:text-white dark:shadow-white dark:focus:ring-yellow-600"
       href="#"

--- a/public/examples/neobrutalism/buttons/4-dark.html
+++ b/public/examples/neobrutalism/buttons/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <a
       class="relative bg-white px-5 py-3 font-semibold text-black after:absolute after:inset-x-0 after:bottom-0 after:h-1 after:bg-black hover:text-white hover:after:h-full focus:ring-2 focus:ring-yellow-300 focus:outline-0 dark:bg-gray-900 dark:text-white dark:after:bg-white dark:hover:text-gray-900 dark:focus:ring-yellow-600"
       href="#"

--- a/public/examples/neobrutalism/buttons/5-dark.html
+++ b/public/examples/neobrutalism/buttons/5-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="flex justify-center p-6">
+  <body class="flex justify-center p-6 dark:bg-gray-900">
     <a
       class="border-2 border-black bg-white px-5 py-3 font-semibold text-black ring-2 ring-black ring-offset-2 ring-offset-yellow-300 hover:bg-yellow-200 focus:ring-2 focus:ring-yellow-300 focus:outline-0 dark:border-white dark:bg-gray-900 dark:text-white dark:ring-white dark:ring-offset-yellow-600 dark:hover:bg-yellow-700 dark:focus:ring-yellow-600"
       href="#"

--- a/public/examples/neobrutalism/cards/1-dark.html
+++ b/public/examples/neobrutalism/cards/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-md p-6">
+  <body class="mx-auto max-w-md p-6 dark:bg-gray-900">
     <a
       href="#"
       class="block border-2 border-black bg-white p-4 text-black shadow-[4px_4px_0_0] shadow-black hover:bg-yellow-200 focus:ring-2 focus:ring-yellow-300 focus:outline-0 sm:p-6 dark:border-white dark:bg-gray-900 dark:text-white dark:shadow-white dark:hover:bg-yellow-700 dark:focus:ring-yellow-600"

--- a/public/examples/neobrutalism/cards/2-dark.html
+++ b/public/examples/neobrutalism/cards/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-md p-6">
+  <body class="mx-auto max-w-md p-6 dark:bg-gray-900">
     <a
       href="#"
       class="block border-2 border-black bg-white p-4 text-black shadow-[4px_4px_0_0,8px_8px_0_0,12px_12px_0_0] shadow-black hover:translate-3 hover:bg-yellow-200 hover:shadow-none focus:ring-2 focus:ring-yellow-300 focus:outline-0 sm:p-6 dark:border-white dark:bg-gray-900 dark:text-white dark:shadow-white dark:hover:bg-yellow-700 dark:focus:ring-yellow-600"

--- a/public/examples/neobrutalism/cards/3-dark.html
+++ b/public/examples/neobrutalism/cards/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-md p-6">
+  <body class="mx-auto max-w-md p-6 dark:bg-gray-900">
     <div class="group/card relative">
       <span
         class="absolute inset-0 border-2 border-dashed border-black bg-white dark:border-white dark:bg-gray-900"

--- a/public/examples/neobrutalism/cards/4-dark.html
+++ b/public/examples/neobrutalism/cards/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-md p-6">
+  <body class="mx-auto max-w-md p-6 dark:bg-gray-900">
     <article
       class="border-2 border-black bg-white text-black shadow-[4px_4px_0_0,8px_8px_0_0] shadow-black dark:border-white dark:bg-gray-900 dark:text-white dark:shadow-white"
     >

--- a/public/examples/neobrutalism/checkboxes/1-dark.html
+++ b/public/examples/neobrutalism/checkboxes/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <fieldset>
       <legend class="sr-only">Checkboxes</legend>
 

--- a/public/examples/neobrutalism/checkboxes/2-dark.html
+++ b/public/examples/neobrutalism/checkboxes/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <fieldset>
       <legend class="sr-only">Checkboxes</legend>
 

--- a/public/examples/neobrutalism/checkboxes/3-dark.html
+++ b/public/examples/neobrutalism/checkboxes/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <fieldset>
       <legend class="sr-only">Checkboxes</legend>
 

--- a/public/examples/neobrutalism/inputs/1-dark.html
+++ b/public/examples/neobrutalism/inputs/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-sm p-6">
+  <body class="mx-auto max-w-sm p-6 dark:bg-gray-900">
     <label for="Email" class="text-black dark:text-white">
       <span class="text-sm font-semibold"> Email </span>
 

--- a/public/examples/neobrutalism/inputs/2-dark.html
+++ b/public/examples/neobrutalism/inputs/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-sm p-6">
+  <body class="mx-auto max-w-sm p-6 dark:bg-gray-900">
     <label for="Email" class="text-black dark:text-white">
       <span class="text-sm font-semibold"> Email </span>
 

--- a/public/examples/neobrutalism/inputs/3-dark.html
+++ b/public/examples/neobrutalism/inputs/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-sm p-6">
+  <body class="mx-auto max-w-sm p-6 dark:bg-gray-900">
     <label for="Search">
       <span class="sr-only"> Search </span>
 

--- a/public/examples/neobrutalism/progress-bars/1-dark.html
+++ b/public/examples/neobrutalism/progress-bars/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-md p-6">
+  <body class="mx-auto max-w-md p-6 dark:bg-gray-900">
     <div
       role="progressbar"
       aria-valuenow="25"

--- a/public/examples/neobrutalism/progress-bars/2-dark.html
+++ b/public/examples/neobrutalism/progress-bars/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-md p-6">
+  <body class="mx-auto max-w-md p-6 dark:bg-gray-900">
     <div
       role="progressbar"
       aria-valuenow="25"

--- a/public/examples/neobrutalism/progress-bars/3-dark.html
+++ b/public/examples/neobrutalism/progress-bars/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-md p-6">
+  <body class="mx-auto max-w-md p-6 dark:bg-gray-900">
     <div
       role="progressbar"
       aria-valuenow="75"

--- a/public/examples/neobrutalism/selects/1-dark.html
+++ b/public/examples/neobrutalism/selects/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-xs p-6">
+  <body class="mx-auto max-w-xs p-6 dark:bg-gray-900">
     <label for="Headline" class="text-black dark:text-white">
       <span class="text-sm font-semibold"> Headliner </span>
 

--- a/public/examples/neobrutalism/selects/2-dark.html
+++ b/public/examples/neobrutalism/selects/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-xs p-6">
+  <body class="mx-auto max-w-xs p-6 dark:bg-gray-900">
     <label for="Headline" class="text-black dark:text-white">
       <span class="text-sm font-semibold"> Headliner </span>
 

--- a/public/examples/neobrutalism/selects/3-dark.html
+++ b/public/examples/neobrutalism/selects/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-xs p-6">
+  <body class="mx-auto max-w-xs p-6 dark:bg-gray-900">
     <label for="Headline" class="text-black dark:text-white">
       <span class="text-sm font-semibold"> Headliner </span>
 

--- a/public/examples/neobrutalism/tabs/1-dark.html
+++ b/public/examples/neobrutalism/tabs/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="border-b-2 border-black px-2 dark:border-white">
       <div role="tablist" class="-mb-0.5 flex">
         <button

--- a/public/examples/neobrutalism/tabs/2-dark.html
+++ b/public/examples/neobrutalism/tabs/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="border-b-2 border-black dark:border-white">
       <div role="tablist" class="-mb-0.5 flex">
         <button

--- a/public/examples/neobrutalism/tabs/3-dark.html
+++ b/public/examples/neobrutalism/tabs/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div>
       <div role="tablist" class="-mb-0.5 flex gap-3">
         <button

--- a/public/examples/neobrutalism/tabs/4-dark.html
+++ b/public/examples/neobrutalism/tabs/4-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-3xl p-6">
+  <body class="mx-auto max-w-3xl p-6 dark:bg-gray-900">
     <div class="flex gap-8">
       <div class="border-r-2 border-black py-2 dark:border-white">
         <div role="tablist" class="-mr-0.5 flex flex-col">

--- a/public/examples/neobrutalism/textareas/1-dark.html
+++ b/public/examples/neobrutalism/textareas/1-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <label for="Notes" class="text-black dark:text-white">
       <span class="text-sm font-semibold"> Notes </span>
 

--- a/public/examples/neobrutalism/textareas/2-dark.html
+++ b/public/examples/neobrutalism/textareas/2-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <label for="Notes" class="text-black dark:text-white">
       <span class="text-sm font-semibold"> Notes </span>
 

--- a/public/examples/neobrutalism/textareas/3-dark.html
+++ b/public/examples/neobrutalism/textareas/3-dark.html
@@ -6,7 +6,7 @@
     <link href="/component.css" rel="stylesheet" />
     <script src="/component.js" defer></script>
   </head>
-  <body class="mx-auto max-w-lg p-6">
+  <body class="mx-auto max-w-lg p-6 dark:bg-gray-900">
     <div>
       <label for="Notes" class="text-black dark:text-white">
         <span class="text-sm font-semibold"> Notes </span>


### PR DESCRIPTION
## Summary

Fixes #753.

Every `-dark.html` file under `public/examples/**` relied entirely on being embedded in `ComponentPreview.astro`'s iframe, which applies `bg-gray-900` to the outer `<iframe>` element. Opened standalone, these files render on the browser's default white canvas instead of a dark backdrop, so `dark:` overrides (borders, hover states, etc.) show poor/near-invisible contrast.

## Approach

The issue proposed two options: a global `html.dark { background-color: ... }` rule in `src/styles/component.css`, or `dark:bg-gray-900` on `<body>` in every dark example file.

I went with the per-file `<body>` approach instead of the global CSS rule. Reason: the ambient `class="dark"` on `<html>` isn't unique to `-dark.html` files — it's already present on plain (light) example files too (confirmed across many collections), just inert there because those files contain no `dark:`-prefixed utilities. A global `html.dark` rule would therefore also paint every light-mode preview's background dark, both standalone and embedded in `ComponentPreview.astro`'s iframe (verified this regression locally before reverting it).

Instead, `dark:bg-gray-900` was added to the `<body>` tag of all 240 `-dark.html` files under `public/examples/**` (scripted edit, then `prettier` to confirm class ordering — no reordering was needed). This targets only the actual dark-variant files and leaves light-mode files untouched. The `dark:bg-gray-900` utility was already compiled into `public/component.css` from existing usage elsewhere, so no CSS rebuild was required.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm dev` + Playwright: confirmed `.../accordions/1-dark.html` now renders with a dark body background when opened standalone
- [x] Confirmed the corresponding light `.../accordions/1.html` file (and its embedded iframe preview on `/components/application/accordions`) is unaffected
- [x] Confirmed `git status` only touched the 240 `-dark.html` files (one line each)

---
_Generated by [Claude Code](https://claude.ai/code/session_0145eeX9FmQuFkghLRC6uTDg)_